### PR TITLE
Smart contracts - batch unlock, settle, balance hash in balance proof

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -57,6 +57,7 @@ TokenNetworksRegistry Contract
 Attributes:
 
 - ``address public secret_registry_address``
+- ``uint256 public chain_id``
 
 **Register a token**
 
@@ -85,6 +86,7 @@ Attributes:
 
 - ``Token public token``
 - ``SecretRegistry public secret_registry;``
+- ``uint256 public chain_id``
 
 **Open a channel**
 

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -309,7 +309,7 @@ Allows the participants to cooperate and provide both of their balances and sign
 SecretRegistry Contract
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-This contract will store secrets revealed in a mediating transfer. It has to keep track of the block height at which the secret was stored.
+This contract will store the block height at which the secret was revealed in a mediating transfer.
 In collaboration with a monitoring service, it acts as a security measure, to allow all nodes participating in a mediating transfer to withdraw the transferred tokens even if some of the nodes might be offline.
 
 ::
@@ -318,14 +318,15 @@ In collaboration with a monitoring service, it acts as a security measure, to al
 
 ::
 
-    event SecretRevealed(bytes32 secret);
+    event SecretRevealed(bytes32 indexed secrethash);
 
 Getters
 ::
 
-    function getSecretBlockHeight(bytes32 secret) public constant returns (uint64)
+    function getSecretRevealBlockHeight(bytes32 secrethash) public view returns (uint256)
 
 - ``secret``: The preimage used to derive a secrethash.
+- ``secrethash``: ``keccak256(secret)``.
 
 Data types definition
 ---------------------

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -260,14 +260,22 @@ Unlocks a pending transfer by providing the secret and increases the partner's t
 
 **Settle channel**
 
-Settles the channel by transferring the amount of tokens each participant is owed.
+Settles the channel by transferring the amount of tokens each participant is owed. We need to provide the entire balance state because we only store the balance data hash when closing the channel and updating the non-closing participant balance.
 
 ::
 
     function settleChannel(
         uint256 channel_identifier,
         address participant1,
-        address participant2)
+        uint256 participant1_transferred_amount,
+        uint256 participant1_locked_amount,
+        bytes32 participant1_locksroot,
+        bytes32 participant1_additional_hash,
+        address participant2,
+        uint256 participant2_transferred_amount,
+        uint256 participant2_locked_amount,
+        bytes32 participant2_locksroot,
+        bytes32 participant2_additional_hash)
         public
 
 ::


### PR DESCRIPTION
- Batch unlock: https://github.com/raiden-network/spec/issues/35
- Monitoring Service is not required to unlock the pending transfer tokens: https://github.com/raiden-network/spec/issues/31
- Use balance hash in balance proofs - ensures privacy, especially when the channel is monitored by a third party. See discussion here: https://github.com/raiden-network/spec/issues/25#issuecomment-375467874, combined with the need to provided the `locked_amount` of tokens in the balance proof, in order to keep it in the smart contract after settling the channel. `unlock` happens after `settleChannel`