### PR TITLE
Specify secret size

### DIFF
--- a/terminology.rst
+++ b/terminology.rst
@@ -143,7 +143,7 @@ Raiden Terminology
        Total fees for a Mediated Transfer announced by the Raiden Node doing the Transfer.
 
    Secret
-       A value used as a preimage in a :term:`Hash Time Locked Transfer`.
+       A value used as a preimage in a :term:`Hash Time Locked Transfer`. Its size should be 32 bytes.
 
    Partner
        The other node in a channel. The node with which we have an open :term:`Payment Channel`.


### PR DESCRIPTION
Fix #60.

@loredanacirstea is that where in the spec you wanted it specified? In all other places it's shown as `bytes32` in the signature of the functions so should be clear.