### PR TITLE
Update smart contracts specs after withdraw, cooperative settle, channel limit

### DIFF
--- a/messaging.rst
+++ b/messaging.rst
@@ -15,7 +15,11 @@ Balance Proof
 -------------
 
 Data required by the smart contracts to update the payment channel end of the participant that signed the balance proof.
-The signature must be valid and is defined as: ``ecdsa_recoverable(privkey, keccak256(balance_hash || nonce || additional_hash || channel_identifier || token_network_address || chain_id)``
+The signature must be valid and is defined as:
+
+::
+
+    ecdsa_recoverable(privkey, keccak256(balance_hash || nonce || additional_hash || channel_identifier || token_network_address || chain_id)
 
 Fields
 ^^^^^^
@@ -52,6 +56,77 @@ Balance Data Hash
 +------------------------+------------+---------------------------------------------------------------------------------------+
 |  locksroot             | bytes32    | Root of merkle tree of all pending lock lockhashes                                    |
 +------------------------+------------+---------------------------------------------------------------------------------------+
+
+.. _withdraw-proof-message:
+
+Withdraw Proof
+--------------
+
+Data required by the smart contracts to allow a user to withdraw funds from a channel without closing it.
+Signature must be valid and is defined as:
+
+::
+
+    ecdsa_recoverable(privkey, sha3_keccak(participant_address || total_withdraw || channel_identifier || token_network_address || chain_id)
+
+Invariants
+^^^^^^^^^^
+
+- ``total_withdraw`` is strictly monotonic increasing. This is required for protection against replay attacks with old withdraw proofs.
+
+Fields
+^^^^^^
+
++------------------------+------------+--------------------------------------------------------------------------------+
+| Field Name             | Field Type |  Description                                                                   |
++========================+============+================================================================================+
+|  participant_address   | address    | Channel participant, who withdraws the tokens                                  |
++------------------------+------------+--------------------------------------------------------------------------------+
+|  total_withdraw        | uint256    | Total amount of tokens that participant_address has withdrawn from the channel |
++------------------------+------------+--------------------------------------------------------------------------------+
+|  channel_identifier    | uint256    | Channel identifier inside the TokenNetwork contract                            |
++------------------------+------------+--------------------------------------------------------------------------------+
+| token_network_address  | address    | Address of the TokenNetwork contract                                           |
++------------------------+------------+--------------------------------------------------------------------------------+
+| chain_id               | uint256    | Chain identifier as defined in EIP155                                          |
++------------------------+------------+--------------------------------------------------------------------------------+
+|  signature             | bytes      | Elliptic Curve 256k1 signature on the above data                               |
++------------------------+------------+--------------------------------------------------------------------------------+
+
+.. _cooperative-settle-proof-message:
+
+Cooperative Settle Proof
+------------------------
+
+Data required by the smart contracts to allow the two channel participants to close and settle the channel instantly, in one transaction.
+Signature must be valid and is defined as:
+
+::
+
+    ecdsa_recoverable(privkey, sha3_keccak(participant1_address || participant1_balance || participant2_address || participant2_balance || channel_identifier || token_network_address || chain_id)
+
+Fields
+^^^^^^
+
++------------------------+------------+--------------------------------------------------------------------------------+
+| Field Name             | Field Type |  Description                                                                   |
++========================+============+================================================================================+
+|  participant1_address  | address    | One of the channel participants                                                |
++------------------------+------------+--------------------------------------------------------------------------------+
+|  participant1_balance  | uint256    | Amount of tokens that participant1_address will receive aftler settling        |
++------------------------+------------+--------------------------------------------------------------------------------+
+|  participant2_address  | address    | The other channel participant                                                  |
++------------------------+------------+--------------------------------------------------------------------------------+
+|  participant2_balance  | uint256    | Amount of tokens that participant2_address will receive aftler settling        |
++------------------------+------------+--------------------------------------------------------------------------------+
+|  channel_identifier    | uint256    | Channel identifier inside the TokenNetwork contract                            |
++------------------------+------------+--------------------------------------------------------------------------------+
+| token_network_address  | address    | Address of the TokenNetwork contract                                           |
++------------------------+------------+--------------------------------------------------------------------------------+
+| chain_id               | uint256    | Chain identifier as defined in EIP155                                          |
++------------------------+------------+--------------------------------------------------------------------------------+
+|  signature             | bytes      | Elliptic Curve 256k1 signature on the above data                               |
++------------------------+------------+--------------------------------------------------------------------------------+
 
 Merkle Tree
 -----------

--- a/messaging.rst
+++ b/messaging.rst
@@ -72,7 +72,7 @@ Signature must be valid and is defined as:
 Invariants
 ^^^^^^^^^^
 
-- ``total_withdraw`` is strictly monotonic increasing. This is required for protection against replay attacks with old withdraw proofs.
+- ``total_withdraw`` is strictly monotonically increasing. This is required for protection against replay attacks with old withdraw proofs.
 
 Fields
 ^^^^^^
@@ -113,11 +113,11 @@ Fields
 +========================+============+================================================================================+
 |  participant1_address  | address    | One of the channel participants                                                |
 +------------------------+------------+--------------------------------------------------------------------------------+
-|  participant1_balance  | uint256    | Amount of tokens that participant1_address will receive aftler settling        |
+|  participant1_balance  | uint256    | Amount of tokens that participant1_address will receive after settling         |
 +------------------------+------------+--------------------------------------------------------------------------------+
 |  participant2_address  | address    | The other channel participant                                                  |
 +------------------------+------------+--------------------------------------------------------------------------------+
-|  participant2_balance  | uint256    | Amount of tokens that participant2_address will receive aftler settling        |
+|  participant2_balance  | uint256    | Amount of tokens that participant2_address will receive after settling         |
 +------------------------+------------+--------------------------------------------------------------------------------+
 |  channel_identifier    | uint256    | Channel identifier inside the TokenNetwork contract                            |
 +------------------------+------------+--------------------------------------------------------------------------------+

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -82,6 +82,10 @@ TokenNetwork Contract
 
 Provides the interface to interact with payment channels. The channels can only transfer the type of token that this contract defines through ``token_address``.
 
+.. _channel-identifier:
+
+:term:`Channel Identifier` is currently defined as ``keccak256(address participant1, address participant2)``, where the two participant addresses are in lexicographic order.
+
 Attributes:
 
 - ``Token public token``
@@ -108,7 +112,7 @@ Opens a channel between ``participant1`` and ``participant2`` and sets the chall
 - ``participant1``: Ethereum address of a channel participant.
 - ``participant2``: Ethereum address of the other channel participant.
 - ``settle_timeout``: Number of blocks that need to be mined between a call to ``closeChannel`` and ``settleChannel``.
-- ``channel_identifier``: Channel identifier assigned by the current contract.
+- ``channel_identifier``: :term:`Channel identifier` assigned by the current contract.
 
 **Fund a channel**
 
@@ -117,9 +121,9 @@ Deposit more tokens into a channel. This will only increase the deposit of one o
 ::
 
     function setDeposit(
-        uint channel_identifier,
         address participant,
-        uint256 total_deposit
+        uint256 total_deposit,
+        address partner
     )
         public
 
@@ -127,9 +131,10 @@ Deposit more tokens into a channel. This will only increase the deposit of one o
 
     event ChannelNewDeposit(uint channel_identifier, address participant, uint deposit);
 
-- ``channel_identifier``: Channel identifier assigned by the current contract.
 - ``participant``: Ethereum address of a channel participant whose deposit will be increased.
 - ``total_deposit``: Total amount of tokens that the ``participant`` will have as ``deposit`` in the channel.
+- ``partner``: Ethereum address of the other channel participant, used for computing ``channel_identifier``.
+- ``channel_identifier``: :term:`Channel identifier` assigned by the current contract.
 - ``deposit``: The total amount of tokens deposited in a channel by a participant.
 
 .. Note::
@@ -189,7 +194,7 @@ Allows a channel participant to close the channel. The channel cannot be settled
 - ``locked_amount``: The sum of the all the tokens that correspond to the locks (pending transfers) contained in the merkle tree.
 - ``locksroot``: Root of the merkle tree of all pending lock lockhashes for the partner.
 - ``signature``: Elliptic Curve 256k1 signature of the channel partner on the :term:`balance proof` data.
-- ``channel_identifier``: Channel identifier assigned by the current contract.
+- ``channel_identifier``: :term:`Channel identifier` assigned by the current contract.
 - ``closing_participant``: Ethereum address of the channel participant who calls this contract function.
 
 .. Note::
@@ -264,7 +269,7 @@ Settles the channel by transferring the amount of tokens each participant is owe
 - ``participant2_transferred_amount``: The monotonically increasing counter of the amount of tokens sent by ``participant2`` to ``participant1``.
 - ``participant2_locked_amount``: The sum of the all the tokens that correspond to the locks (pending transfers sent by ``participant2`` to ``participant1``) contained in the merkle tree.
 - ``participant2_locksroot``: Root of the merkle tree of all pending lock lockhashes (pending transfers sent by ``participant2`` to ``participant1``).
-- ``channel_identifier``: Channel identifier assigned by the current contract.
+- ``channel_identifier``: :term:`Channel identifier` assigned by the current contract.
 
 .. Note::
     Can be called by anyone after a channel has been closed and the challenge period is over.
@@ -317,11 +322,11 @@ Unlocks all pending transfers by providing the entire merkle tree of pending tra
 
 - ``participant``: Ethereum address of the channel participant who will receive the unlocked tokens that correspond to the pending transfers that have a revealed secret.
 - ``partner``: Ethereum address of the channel participant that pays the amount of tokens that correspond to the pending transfers that have a revealed secret. This address will receive the rest of the tokens that correspond to the pending transfers that have not finalized and do not have a revelead secret.
-- ``merkle_tree_leaves``: The entire merkle tree of pending transfers. It contains tightly packed data for each transfer, consisting of ``expiration_block``, ``locked_amount``, ``secrethash``.
+- ``merkle_tree_leaves``: The data for computing the entire merkle tree of pending transfers. It contains tightly packed data for each transfer, consisting of ``expiration_block``, ``locked_amount``, ``secrethash``.
 - ``expiration_block``: The absolute block number at which the lock expires.
 - ``locked_amount``: The number of tokens being transferred from ``partner`` to ``participant`` in a pending transfer.
 - ``secrethash``: A hashed secret, ``sha3_keccack(secret)``.
-- ``channel_identifier``: Channel identifier assigned by the current contract.
+- ``channel_identifier``: :term:`Channel identifier` assigned by the current contract.
 - ``unlocked_amount``: The total amount of unlocked tokens that the ``partner`` owes to the channel ``participant``.
 - ``returned_tokens``: The total amount of unlocked tokens that return to the ``partner`` because the secret was not revealed, therefore the mediating transfer did not occur.
 

--- a/terminology.rst
+++ b/terminology.rst
@@ -10,6 +10,9 @@ Raiden Terminology
    payment channel
        An object living on a blockchain that has all the capabilities required to enable secure off-chain payment channels.
 
+   channel identifier
+       Identifier assigned by :term:`Token Network` to a :term:`Payment Channel`. Must be unique inside the :term:`Token Network` contract. See the :ref:`implementation definition <channel-identifier>`.
+
    Unidirectional Payment Channel
        Payment Channel where the roles of :term:`Initiator` and :term:`Target` are determined in the channel creation and cannot be changed.
 
@@ -77,7 +80,7 @@ Raiden Terminology
        Signed data required by the :term:`Payment Channel` to allow a participant to withdraw tokens. See the :ref:`message definition <withdraw-proof-message>`.
 
    cooperative settle proof
-       Signed data required by the :term:`Payment Channel` to allow :term:`Participants` to close and settle a :term:`Payment Channel` without a :term:`Settlement Window`. See the :ref:`message definition <cooperative-settle-proof-message>`.
+       Signed data required by the :term:`Payment Channel` to allow :term:`Participants` to close and settle a :term:`Payment Channel` without undergoing through the :term:`Settlement Window`. See the :ref:`message definition <cooperative-settle-proof-message>`.
 
    Message
        Any message sent from one Raiden Node to the other.

--- a/terminology.rst
+++ b/terminology.rst
@@ -72,6 +72,13 @@ Raiden Terminology
    BP
        Signed data required by the :term:`Payment Channel` to prove the balance of one of the parties. See the :ref:`message definition <balance-proof-message>`.
 
+   withdraw proof
+   Participant Withdraw Proof
+       Signed data required by the :term:`Payment Channel` to allow a participant to withdraw tokens. See the :ref:`message definition <withdraw-proof-message>`.
+
+   cooperative settle proof
+       Signed data required by the :term:`Payment Channel` to allow :term:`Participants` to close and settle a :term:`Payment Channel` without a :term:`Settlement Window`. See the :ref:`message definition <cooperative-settle-proof-message>`.
+
    Message
        Any message sent from one Raiden Node to the other.
 


### PR DESCRIPTION
fixes https://github.com/raiden-network/spec/issues/70 (TokenNetwork `ChannelSettled` event - add the transferred amounts as arguments)
fixes https://github.com/raiden-network/spec/issues/71 (add cooperative settle signature format)
fixes https://github.com/raiden-network/spec/issues/75 (Update smart contract specs after `channel_identifier` changes from limiting the number of channels between two participants to one)
fixes https://github.com/raiden-network/spec/issues/26 (adds withdraw specs for smart contracts and messages)