### PR TITLE
Add fields in the pahtfinding service API call

### DIFF
--- a/pathfinding_service.rst
+++ b/pathfinding_service.rst
@@ -98,12 +98,15 @@ Example
         "balance_proof": {
             "nonce": 1234,
             "transferred_amount": 23,
+            "locked_amount": 0,
             "locksroot": "<keccak-hash>",
             "channel_id": 123,
-            "token_network_address": "0xtoken"],
+            "token_network_address": "0xtoken",
             "chain_id": 1,
             "additional_hash": "<keccak-hash>",
-            "signature": "<signature>"
+            "balance_hash": "<keccak-hash>",
+            "signature": "<signature>",
+            "message_type": "BalanceProof",
         },
         "locks": [
             {


### PR DESCRIPTION
An example of a PUT /balance call on the pathfinding service didn't have some JSON fields.

This commit adds fields seen in a unit test (see https://github.com/raiden-network/spec/issues/130#issuecomment-439424438 )

Fixes #130.
