### PR TITLE
Balance Proof Update not Balance Update Proof

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -120,9 +120,9 @@ Balance Data Hash
 |  locksroot             | bytes32    | Root of merkle tree of all pending lock lockhashes                                    |
 +------------------------+------------+---------------------------------------------------------------------------------------+
 
-.. _balance-update-proof-message:
+.. _balance-proof-update-onchain:
 
-Balance Update Proof
+Balance Proof Update
 --------------------
 
 ::
@@ -561,7 +561,9 @@ Called after a channel has been closed. Can be called by any Ethereum address an
 
     Only a valid signed :term:`balance proof` from the channel's ``closing participant`` (the other channel participant) ``MUST`` be accepted. This :term:`balance proof` sets the amount of tokens owed to the ``non-closing participant`` by the ``closing participant``.
 
-    Only a valid signed balance proof update message  ``MUST`` be accepted. This message is a confirmation from the ``non-closing participant`` that the contained :term:`balance proof` can be set on his behalf.
+    Only a valid signed `balance proof update`__ message  ``MUST`` be accepted. This message is a confirmation from the ``non-closing participant`` that the contained :term:`balance proof` can be set on his behalf.
+
+    __ balance-proof-update-onchain_
 
 .. _settle-channel:
 


### PR DESCRIPTION
Both "balance proof update"s and "balance update proof"s appeared in the specification.  I think it's a balance proof update because it's about updating the balance proof.

Also added a cross-reference.