### PR TITLE
Update description of additional_hash

### DIFF
--- a/messaging.rst
+++ b/messaging.rst
@@ -23,6 +23,8 @@ The signature must be valid and is defined as:
 
     ecdsa_recoverable(privkey, keccak256(balance_hash || nonce || additional_hash || channel_identifier || token_network_address || chain_id))
 
+Also see :term:`additional_hash`.
+
 Fields
 ^^^^^^
 

--- a/terminology.rst
+++ b/terminology.rst
@@ -172,7 +172,7 @@ Raiden Terminology
 
    Additional Hash
    additional_hash
-       Hash of additional data used on the application layer. This can for example be some form of payment metadata. The Raiden Network protocol does not use or enforce the type or content of this additional data.
+       Hash of additional data (in addition to a balance proof itself) used on the Raiden protocol (and potentially in the future also the application layer). Currently this is the hash of the offchain message that contains the balance proof. In the future, for example, some form of payment metadata can be hashed in.
 
    Payment Receipt
        TBD


### PR DESCRIPTION
1. clarify additional_hash is in addition to what
2. explain that additional_hash is currently the hash of the offchain message
3. add a link from messaging.rst into additional_hash in the terminology.

This commit rescues some results from the discussion here https://github.com/raiden-network/spec/pull/136#discussion_r237393201