### PR TITLE
Add Locked Transfer in the terminology

### DIFF
--- a/messaging.rst
+++ b/messaging.rst
@@ -238,7 +238,7 @@ A :term:`Mediated Transfer` is a hash-time-locked transfer. Currently raiden sup
 
 Mediated transfers have an :term:`initiator` and a :term:`target` and a number of mediators in between. The number of mediators can also be zero as these transfers can also be sent to a direct partner. Assuming ``N`` number of mediators, a mediated transfer will require ``10N + 16`` messages to complete. These are:
 
-- ``N + 1`` mediated or refund messages
+- ``N + 1`` :term:`locked transfer` or refund messages
 - ``1`` secret request
 - ``N + 2`` secret reveal
 - ``N + 1`` unlock

--- a/terminology.rst
+++ b/terminology.rst
@@ -112,6 +112,10 @@ Raiden Terminology
    Outbound Transfer
        A :term:`locked transfer` sent by a node. The node may be a :term:`Mediator` in the path or the :term:`Initiator`.
 
+   Locked Transfer
+   Locked Transfer message
+       An offchain Raiden message that reserves an amount of tokens for a specific :term:`Payment`. See :ref:`locked-transfer-message` for details.
+
    Monitoring Service
    MS
        The service that monitors channel state on behalf of the user and takes an action if the channel is being closed with a balance proof that would violate the agreed on balances. Responsibilities


### PR DESCRIPTION
There were some links to :term:`Locked Transfer` but `terminology.rst` did not have that entry.

This is a part of https://github.com/raiden-network/spec/issues/162.