### PR TITLE
Add a short description to TokenNetworkRegistry

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -257,6 +257,9 @@ Smart Contract Functional Decomposition
 TokenNetworkRegistry Contract
 -----------------------------
 
+This contract creates and remembers a TokenNetwork contract for an ERC20 Token.  Raiden clients listen to ``TokenNetworkCreated`` events so they can notice when this contract deploys a new ``TokenNetwork``.
+
+
 Attributes:
 
 - ``address public secret_registry_address``


### PR DESCRIPTION
The specification of TokenNetworkRegistry contract lacked an
introductory short summary.