### PR TITLE
Secret Reveal messages in the terminology

### DIFF
--- a/messaging.rst
+++ b/messaging.rst
@@ -302,7 +302,7 @@ Mediated transfers have an :term:`initiator` and a :term:`target` and a number o
 
 - ``N + 1`` :term:`locked transfer` or refund messages
 - ``1`` secret request
-- ``N + 2`` secret reveal
+- ``N + 2`` :term:`secret reveal`
 - ``N + 1`` :term:`unlock`
 - ``2N + 3`` processed (one for everything above)
 - ``5N + 8`` delivered

--- a/terminology.rst
+++ b/terminology.rst
@@ -157,6 +157,10 @@ Raiden Terminology
    Settle Timeout
        The number of blocks from the time of closing of a channel until it can be settled.
 
+   Secret Reveal
+   Secret Reveal message
+       An offchain Raiden message that contains the secret that can open a Hash Time Lock. See :ref:`secret-reveal-message` for details.
+
    Reveal Timeout
           The number of blocks in a channel allowed for learning about a secret being revealed through the blockchain and acting on it.
 


### PR DESCRIPTION
This commit adds Secret Reveal messages in the terminology, and adds a link to the new entry.

This work is a part of https://github.com/raiden-network/spec/issues/162