### PR TITLE
Rephrase "non-closing participant balance proof"

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -525,7 +525,7 @@ Allows a channel participant to close the channel. The channel cannot be settled
 
 .. _update-channel:
 
-**Update non-closing participant balance proof**
+**Update the balance proof counting towards the non-closing participant**
 
 Called after a channel has been closed. Can be called by any Ethereum address and allows the non-closing participant to provide the latest :term:`balance proof` from the closing participant. This modifies the stored state for the closing participant.
 


### PR DESCRIPTION
There was a section titled "Update non-closing participant balance proof" which was not clear. This could be about the balance proof signed by the non-closing participant or the balance proof useful for the non-closing participant. Actually, this section is about the balance proof useful for the non-closing participant.