### PR TITLE
Explain settle_block_number from getChannelInfo()

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -335,7 +335,7 @@ We currently limit the number of channels between two participants to one. There
 - ``participant1``: Ethereum address of a channel participant.
 - ``participant2``: Ethereum address of the other channel participant.
 - ``state``: Channel state. It can be ``NonExistent`` - ``0``, ``Opened`` - ``1``, ``Closed`` - ``2``, ``Settled`` - ``3``, ``Removed`` - ``4``.
-- ``settle_block_number``: the number of blocks in the settlement window if ``state`` is ``Opened``; the block number after which settleChannel() can succeed if ``state`` is ``Closed``; 0 otherwise.
+- ``settle_block_number``: the number of blocks in the challenge period if ``state`` is ``Opened``; the block number after which settleChannel() can succeed if ``state`` is ``Closed``; 0 otherwise.
 
 .. Note::
     Channel state ``Settled`` means the channel was settled and channel data removed. However, there is still data remaining in the contract for calling ``unlock`` - for at least one participant.
@@ -784,13 +784,13 @@ Channel Settlement
     :alt: Channel Settlement
     :width: 400px
 
-Channel Settlement Window
--------------------------
+Channel Challenge Period
+------------------------
 
-The non-closing participant can update the closing participant's balance proof during the settlement window, by calling ``TokenNetwork.updateNonClosingBalanceProof``.
+The non-closing participant can update the closing participant's balance proof during the challenge period, by calling ``TokenNetwork.updateNonClosingBalanceProof``.
 
 .. image:: diagrams/RaidenSC_channel_update.png
-    :alt: Channel Settlement Window Updating NonClosing BalanceProof
+    :alt: Channel Challenge Period Updating NonClosing BalanceProof
     :width: 650px
 
 Unlocking Pending Transfers

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -335,7 +335,7 @@ We currently limit the number of channels between two participants to one. There
 - ``participant1``: Ethereum address of a channel participant.
 - ``participant2``: Ethereum address of the other channel participant.
 - ``state``: Channel state. It can be ``NonExistent`` - ``0``, ``Opened`` - ``1``, ``Closed`` - ``2``, ``Settled`` - ``3``, ``Removed`` - ``4``.
-- ``settle_block_number``: the number of blocks in the challenge period if ``state`` is ``Opened``; the block number after which settleChannel() can succeed if ``state`` is ``Closed``; 0 otherwise.
+- ``settle_block_number``: the number of blocks in the :term:`challenge period` if ``state`` is ``Opened``; the block number after which settleChannel() can succeed if ``state`` is ``Closed``; 0 otherwise.
 
 .. Note::
     Channel state ``Settled`` means the channel was settled and channel data removed. However, there is still data remaining in the contract for calling ``unlock`` - for at least one participant.

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -335,6 +335,7 @@ We currently limit the number of channels between two participants to one. There
 - ``participant1``: Ethereum address of a channel participant.
 - ``participant2``: Ethereum address of the other channel participant.
 - ``state``: Channel state. It can be ``NonExistent`` - ``0``, ``Opened`` - ``1``, ``Closed`` - ``2``, ``Settled`` - ``3``, ``Removed`` - ``4``.
+- ``settle_block_number``: the number of blocks in the settlement window if ``state`` is ``Opened``; the block number after which settleChannel() can succeed if ``state`` is ``Closed``; 0 otherwise.
 
 .. Note::
     Channel state ``Settled`` means the channel was settled and channel data removed. However, there is still data remaining in the contract for calling ``unlock`` - for at least one participant.

--- a/terminology.rst
+++ b/terminology.rst
@@ -147,15 +147,13 @@ Raiden Terminology
    Net Balance
        Net of balance in a contract. May be negative or positive. Negative for ``A(B)`` if ``A(B)`` received more tokens than it spent. For example ``net_balance(A) = transferred_amount(A) - transferred_amount(B)``
 
-   Challenge Period
-       The state of a channel initiated by one of the channel participants. This phase is limited for a period of ``n`` block updates.
-
    Challenge Period Update
-       Update of the channel state during the :term:`Challenge period`. The state can be updated either by the channel participants, or by a delegate (:term:`MS`).
+       Update of the channel state during the :term:`Challenge period`. The state can be updated either by the non-closing participant, or by a delegate (:term:`MS`).
 
+   Challenge Period
    Settlement Window
    Settle Timeout
-       The number of blocks from the time of closing of a channel until it can be settled.
+       The state of a channel after one channel participant closes the channel. During this period the other participant (or any delegate) is able to provide balance proofs by calling :ref:`updateNonClosingBalanceProof() <update-channel>`. This phase is limited for a number of blocks, after which the channel can be :ref:`settled <settle-channel>`. The length of the challenge period can be configured when each channel is opened.
 
    Secret Reveal
    Secret Reveal message


### PR DESCRIPTION
The meaning of ``settle_block_number`` is worth explaining because the number means different things according to different states of the channel.