### PR TITLE
Document the fact that registerSecret() fails if

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -724,7 +724,7 @@ Getters
 
     function getSecretRevealBlockHeight(bytes32 secrethash) public view returns (uint256)
 
-- ``secret``: The preimage used to derive a secrethash.
+- ``secret``: The preimage used to derive a secrethash. Currently, ``registerSecret()`` fails if the ``secret`` is zero.
 - ``secrethash``: ``keccak256(secret)``.
 
 


### PR DESCRIPTION
the secret is zero.