### PR TITLE
Add a missing link to terminology

### DIFF
--- a/messaging.rst
+++ b/messaging.rst
@@ -312,7 +312,7 @@ A :term:`Mediated Transfer` is a hash-time-locked transfer. Currently raiden sup
 Mediated transfers have an :term:`initiator` and a :term:`target` and a number of mediators in between. The number of mediators can also be zero as these transfers can also be sent to a direct partner. Assuming ``N`` number of mediators, a mediated transfer will require ``10N + 16`` messages to complete. These are:
 
 - ``N + 1`` :term:`locked transfer` or :term:`refund transfer` messages
-- ``1`` secret request
+- ``1`` :term:`secret request`
 - ``N + 2`` :term:`reveal secret`
 - ``N + 1`` :term:`unlock`
 - ``2N + 3`` processed (one for everything above)


### PR DESCRIPTION
This fixes #162