### PR TITLE
Add a copy of the contracts to repo for autodoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 _build/
 .vscode/
 .idea/
-contracts

--- a/Makefile
+++ b/Makefile
@@ -44,59 +44,59 @@ help:
 	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
 	@echo "  coverage   to run coverage check of the documentation (if enabled)"
 	@echo "  dummy      to check syntax errors of document sources"
+	@echo "  update_contracts      to update the contracts code copy used for autodoc"
 
 .PHONY: clean
 clean:
-	rm -rf $(BUILDDIR)/* contracts
+	rm -rf $(BUILDDIR)/*
 
-# download `raiden-contracts/raiden_contracts/contracts` to the local `contracts` dir
-# This is skipped if the dir already exists. Use `make clean` to force an update.
+# Download `raiden-contracts/raiden_contracts/contracts` to the local
+# `contracts` dir to provide up-to-date contracts for the solidity autodoc.
 # I'd like to use `tar xvz --wildcards '*/raiden_contracts/contracts' --strip-components 2`,
 # but that only works with gnu tar and this should run on MacOS, too.
-contracts:
-	mkdir contracts
+update_contracts:
 	curl -sSL https://github.com/raiden-network/raiden-contracts/tarball/master | tar xvz --directory contracts --strip-components 3
 	find contracts/ -not -name '*.sol' -not -exec rm {} \;
 
 .PHONY: html
-html: contracts
+html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html -W
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
 
 .PHONY: dirhtml
-dirhtml: contracts
+dirhtml:
 	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml -W
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
 
 .PHONY: singlehtml
-singlehtml: contracts
+singlehtml:
 	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml -W
 	@echo
 	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
 
 .PHONY: pickle
-pickle: contracts
+pickle:
 	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle -W
 	@echo
 	@echo "Build finished; now you can process the pickle files."
 
 .PHONY: json
-json: contracts
+json:
 	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json -W
 	@echo
 	@echo "Build finished; now you can process the JSON files."
 
 .PHONY: htmlhelp
-htmlhelp: contracts
+htmlhelp:
 	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp -W
 	@echo
 	@echo "Build finished; now you can run HTML Help Workshop with the" \
 	      ".hhp project file in $(BUILDDIR)/htmlhelp."
 
 .PHONY: qthelp
-qthelp: contracts
+qthelp:
 	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp -W
 	@echo
 	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
@@ -106,7 +106,7 @@ qthelp: contracts
 	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/Raiden.qhc"
 
 .PHONY: applehelp
-applehelp: contracts
+applehelp:
 	$(SPHINXBUILD) -b applehelp $(ALLSPHINXOPTS) $(BUILDDIR)/applehelp -W
 	@echo
 	@echo "Build finished. The help book is in $(BUILDDIR)/applehelp."
@@ -115,7 +115,7 @@ applehelp: contracts
 	      "bundle."
 
 .PHONY: devhelp
-devhelp: contracts
+devhelp:
 	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp -W
 	@echo
 	@echo "Build finished."
@@ -125,19 +125,19 @@ devhelp: contracts
 	@echo "# devhelp"
 
 .PHONY: epub
-epub: contracts
+epub:
 	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub -W
 	@echo
 	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
 
 .PHONY: epub3
-epub3: contracts
+epub3:
 	$(SPHINXBUILD) -b epub3 $(ALLSPHINXOPTS) $(BUILDDIR)/epub3 -W
 	@echo
 	@echo "Build finished. The epub3 file is in $(BUILDDIR)/epub3."
 
 .PHONY: latex
-latex: contracts
+latex:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex -W
 	@echo
 	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
@@ -145,33 +145,33 @@ latex: contracts
 	      "(use \`make latexpdf' here to do that automatically)."
 
 .PHONY: latexpdf
-latexpdf: contracts
+latexpdf:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex -W
 	@echo "Running LaTeX files through pdflatex..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 .PHONY: latexpdfja
-latexpdfja: contracts
+latexpdfja:
 	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex -W
 	@echo "Running LaTeX files through platex and dvipdfmx..."
 	$(MAKE) -C $(BUILDDIR)/latex all-pdf-ja
 	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
 
 .PHONY: text
-text: contracts
+text:
 	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text -W
 	@echo
 	@echo "Build finished. The text files are in $(BUILDDIR)/text."
 
 .PHONY: man
-man: contracts
+man:
 	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man -W
 	@echo
 	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
 
 .PHONY: texinfo
-texinfo: contracts
+texinfo:
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo -W
 	@echo
 	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
@@ -179,57 +179,57 @@ texinfo: contracts
 	      "(use \`make info' here to do that automatically)."
 
 .PHONY: info
-info: contracts
+info:
 	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo -W
 	@echo "Running Texinfo files through makeinfo..."
 	make -C $(BUILDDIR)/texinfo info
 	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
 
 .PHONY: gettext
-gettext: contracts
+gettext:
 	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale -W
 	@echo
 	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
 
 .PHONY: changes
-changes: contracts
+changes:
 	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes -W
 	@echo
 	@echo "The overview file is in $(BUILDDIR)/changes."
 
 .PHONY: linkcheck
-linkcheck: contracts
+linkcheck:
 	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck -W
 	@echo
 	@echo "Link check complete; look for any errors in the above output " \
 	      "or in $(BUILDDIR)/linkcheck/output.txt."
 
 .PHONY: doctest
-doctest: contracts
+doctest:
 	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest -W
 	@echo "Testing of doctests in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/doctest/output.txt."
 
 .PHONY: coverage
-coverage: contracts
+coverage:
 	$(SPHINXBUILD) -b coverage $(ALLSPHINXOPTS) $(BUILDDIR)/coverage -W
 	@echo "Testing of coverage in the sources finished, look at the " \
 	      "results in $(BUILDDIR)/coverage/python.txt."
 
 .PHONY: xml
-xml: contracts
+xml:
 	$(SPHINXBUILD) -b xml $(ALLSPHINXOPTS) $(BUILDDIR)/xml -W
 	@echo
 	@echo "Build finished. The XML files are in $(BUILDDIR)/xml."
 
 .PHONY: pseudoxml
-pseudoxml: contracts
+pseudoxml:
 	$(SPHINXBUILD) -b pseudoxml $(ALLSPHINXOPTS) $(BUILDDIR)/pseudoxml -W
 	@echo
 	@echo "Build finished. The pseudo-XML files are in $(BUILDDIR)/pseudoxml."
 
 .PHONY: dummy
-dummy: contracts
+dummy:
 	$(SPHINXBUILD) -b dummy $(ALLSPHINXOPTS) $(BUILDDIR)/dummy -W
 	@echo
 	@echo "Build finished. Dummy builder generates no files."

--- a/contracts/EndpointRegistry.sol
+++ b/contracts/EndpointRegistry.sol
@@ -1,0 +1,55 @@
+pragma solidity ^0.5.2;
+
+/// @title Endpoint Registry
+/// @notice This contract is a registry which maps an Ethereum address to its
+/// endpoint. The Raiden node registers its ethereum address in this registry.
+contract EndpointRegistry {
+    string constant public contract_version = "0.5.0";
+
+    event AddressRegistered(address indexed eth_address, string endpoint);
+    mapping (address => string) private address_to_endpoint;
+
+    modifier noEmptyString(string memory str) {
+        require(equals(str, "") != true);
+        _;
+    }
+
+    /// @notice Registers the Ethereum address to the given endpoint.
+    /// @param endpoint String in the format "127.0.0.1:38647".
+    function registerEndpoint(string memory endpoint)
+        public
+        noEmptyString(endpoint)
+    {
+        string storage old_endpoint = address_to_endpoint[msg.sender];
+
+        // Compare if the new endpoint matches the old one, if it does just
+        // return
+        if (equals(old_endpoint, endpoint)) {
+            return;
+        }
+
+        // Update the storage with the new endpoint value
+        address_to_endpoint[msg.sender] = endpoint;
+        emit AddressRegistered(msg.sender, endpoint);
+    }
+
+    /// @notice Finds the endpoint if given a registered Ethereum address.
+    /// @param eth_address A 20 byte Ethereum address.
+    /// @return endpoint which the current Ethereum address is using.
+    function findEndpointByAddress(address eth_address)
+        public
+        view
+        returns (string memory endpoint)
+    {
+        return address_to_endpoint[eth_address];
+    }
+
+    /// @notice Checks if two strings are equal or not.
+    /// @param a First string.
+    /// @param b Second string.
+    /// @return result True if `a` and `b` are equal, false otherwise.
+    function equals(string memory a, string memory b) internal pure returns (bool result)
+    {
+        return (keccak256(abi.encodePacked(a)) == keccak256(abi.encodePacked(b)));
+    }
+}

--- a/contracts/SecretRegistry.sol
+++ b/contracts/SecretRegistry.sol
@@ -1,0 +1,50 @@
+pragma solidity ^0.5.2;
+
+/// @title SecretRegistry
+/// @notice SecretRegistry contract for registering secrets from Raiden Network
+/// clients.
+contract SecretRegistry {
+
+    string constant public contract_version = "0.5.0";
+
+    // keccak256(secret) => block number at which the secret was revealed
+    mapping(bytes32 => uint256) private secrethash_to_block;
+
+    event SecretRevealed(bytes32 indexed secrethash, bytes32 secret);
+
+    /// @notice Registers a hash time lock secret and saves the block number.
+    /// This allows the lock to be unlocked after the expiration block.
+    /// @param secret The secret used to lock the hash time lock.
+    /// @return true if secret was registered, false if the secret was already
+    /// registered.
+    function registerSecret(bytes32 secret) public returns (bool) {
+        bytes32 secrethash = keccak256(abi.encodePacked(secret));
+        if (secret == bytes32(0x0) || secrethash_to_block[secrethash] > 0) {
+            return false;
+        }
+        secrethash_to_block[secrethash] = block.number;
+        emit SecretRevealed(secrethash, secret);
+        return true;
+    }
+
+    /// @notice Registers multiple hash time lock secrets and saves the block
+    /// number.
+    /// @param secrets The array of secrets to be registered.
+    /// @return true if all secrets could be registered, false otherwise.
+    function registerSecretBatch(bytes32[] memory secrets) public returns (bool) {
+        bool completeSuccess = true;
+        for(uint i = 0; i < secrets.length; i++) {
+            if(!registerSecret(secrets[i])) {
+                completeSuccess = false;
+            }
+        }
+        return completeSuccess;
+    }
+
+    /// @notice Get the stored block number at which the secret was revealed.
+    /// @param secrethash The hash of the registered secret `keccak256(secret)`.
+    /// @return The block number at which the secret was revealed.
+    function getSecretRevealBlockHeight(bytes32 secrethash) public view returns (uint256) {
+        return secrethash_to_block[secrethash];
+    }
+}

--- a/contracts/Token.sol
+++ b/contracts/Token.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.5.2;
+
+interface Token {
+
+    /// @return total amount of tokens
+    function totalSupply() external view returns (uint256 supply);
+
+    /// @param _owner The address from which the balance will be retrieved
+    /// @return The balance
+    function balanceOf(address _owner) external view returns (uint256 balance);
+
+    /// @notice send `_value` token to `_to` from `msg.sender`
+    /// @param _to The address of the recipient
+    /// @param _value The amount of token to be transferred
+    /// @return Whether the transfer was successful or not
+    function transfer(address _to, uint256 _value) external returns (bool success);
+
+    /// @notice send `_value` token to `_to` from `_from` on the condition it is approved by `_from`
+    /// @param _from The address of the sender
+    /// @param _to The address of the recipient
+    /// @param _value The amount of token to be transferred
+    /// @return Whether the transfer was successful or not
+    function transferFrom(address _from, address _to, uint256 _value) external returns (bool success);
+
+    /// @notice `msg.sender` approves `_spender` to spend `_value` tokens
+    /// @param _spender The address of the account able to transfer the tokens
+    /// @param _value The amount of wei to be approved for transfer
+    /// @return Whether the approval was successful or not
+    function approve(address _spender, uint256 _value) external returns (bool success);
+
+    /// @param _owner The address of the account owning tokens
+    /// @param _spender The address of the account able to transfer the tokens
+    /// @return Amount of remaining tokens allowed to spent
+    function allowance(address _owner, address _spender) external view returns (uint256 remaining);
+
+    event Transfer(address indexed _from, address indexed _to, uint256 _value);
+    event Approval(address indexed _owner, address indexed _spender, uint256 _value);
+
+    // Optionally implemented function to show the number of decimals for the token
+    function decimals() external view returns (uint8 decimals);
+}

--- a/contracts/TokenNetwork.sol
+++ b/contracts/TokenNetwork.sol
@@ -1,0 +1,1684 @@
+pragma solidity ^0.5.2;
+
+import "raiden/Token.sol";
+import "raiden/Utils.sol";
+import "raiden/lib/ECVerify.sol";
+import "raiden/SecretRegistry.sol";
+
+/// @title TokenNetwork
+/// @notice Stores and manages all the Raiden Network channels that use the
+/// token specified
+/// in this TokenNetwork contract.
+contract TokenNetwork is Utils {
+
+    string constant public contract_version = "0.5.0";
+
+    // Instance of the token used by the channels
+    Token public token;
+
+    // Instance of SecretRegistry used for storing secrets revealed in a
+    // mediating transfer.
+    SecretRegistry public secret_registry;
+
+    // Chain ID as specified by EIP155 used in balance proof signatures to
+    // avoid replay attacks
+    uint256 public chain_id;
+
+    uint256 public settlement_timeout_min;
+    uint256 public settlement_timeout_max;
+
+    uint256 constant public MAX_SAFE_UINT256 = (
+        115792089237316195423570985008687907853269984665640564039457584007913129639935
+    );
+
+    // Red Eyes release deposit limits
+    // The combined deposit of one channel is limited to 0.15 ETH.
+    // So 0.075 ETH per participant.
+    uint256 constant public channel_participant_deposit_limit = 75000000000000000 wei;
+    // The total combined deposit of all channels across the whole network is
+    // limited to 250 ETH.
+    uint256 constant public token_network_deposit_limit = 250000000000000000000 wei;
+
+    // Global, monotonically increasing counter that keeps track of all the
+    // opened channels in this contract
+    uint256 public channel_counter;
+
+    string public constant signature_prefix = '\x19Ethereum Signed Message:\n';
+
+    // Only for the limited Red Eyes release
+    address public deprecation_executor;
+    bool public safety_deprecation_switch = false;
+
+    // channel_identifier => Channel
+    // channel identifier is the channel_counter value at the time of opening
+    // the channel
+    mapping (uint256 => Channel) public channels;
+
+    // This is needed to enforce one channel per pair of participants
+    // The key is keccak256(participant1_address, participant2_address)
+    mapping (bytes32 => uint256) public participants_hash_to_channel_identifier;
+
+    // We keep the unlock data in a separate mapping to allow channel data
+    // structures to be removed when settling uncooperatively. If there are
+    // locked pending transfers, we need to store data needed to unlock them at
+    // a later time.
+    // The key is `keccak256(uint256 channel_identifier, address participant,
+    // address partner)` Where `participant` is the participant that sent the
+    // pending transfers We need `partner` for knowing where to send the
+    // claimable tokens
+    mapping(bytes32 => UnlockData) private unlock_identifier_to_unlock_data;
+
+    struct Participant {
+        // Total amount of tokens transferred to this smart contract through
+        // the `setTotalDeposit` function, for a specific channel, in the
+        // participant's benefit.
+        // This is a strictly monotonic value. Note that direct token transfer
+        // into the contract cannot be tracked and will be stuck.
+        uint256 deposit;
+
+        // Total amount of tokens withdrawn by the participant during the
+        // lifecycle of this channel.
+        // This is a strictly monotonic value.
+        uint256 withdrawn_amount;
+
+        // This is a value set to true after the channel has been closed, only
+        // if this is the participant who closed the channel.
+        bool is_the_closer;
+
+        // keccak256 of the balance data provided after a closeChannel or an
+        // updateNonClosingBalanceProof call
+        bytes32 balance_hash;
+
+        // Monotonically increasing counter of the off-chain transfers,
+        // provided along with the balance_hash
+        uint256 nonce;
+    }
+
+    enum ChannelState {
+        NonExistent, // 0
+        Opened,      // 1
+        Closed,      // 2
+        Settled,     // 3; Note: The channel has at least one pending unlock
+        Removed      // 4; Note: Channel data is removed, there are no pending unlocks
+    }
+
+    enum MessageTypeId {
+        None,
+        BalanceProof,
+        BalanceProofUpdate,
+        Withdraw,
+        CooperativeSettle
+    }
+
+    struct Channel {
+        // After opening the channel this value represents the settlement
+        // window. This is the number of blocks that need to be mined between
+        // closing the channel uncooperatively and settling the channel.
+        // After the channel has been uncooperatively closed, this value
+        // represents the block number after which settleChannel can be called.
+        uint256 settle_block_number;
+
+        ChannelState state;
+
+        mapping(address => Participant) participants;
+    }
+
+    struct SettlementData {
+        uint256 deposit;
+        uint256 withdrawn;
+        uint256 transferred;
+        uint256 locked;
+    }
+
+    struct UnlockData {
+        // Merkle root of the pending transfers tree from the Raiden client
+        bytes32 locksroot;
+        // Total amount of tokens locked in the pending transfers corresponding
+        // to the `locksroot`
+        uint256 locked_amount;
+    }
+
+    event ChannelOpened(
+        uint256 indexed channel_identifier,
+        address indexed participant1,
+        address indexed participant2,
+        uint256 settle_timeout
+    );
+
+    event ChannelNewDeposit(
+        uint256 indexed channel_identifier,
+        address indexed participant,
+        uint256 total_deposit
+    );
+
+    // total_withdraw is how much the participant has withdrawn during the
+    // lifetime of the channel. The actual amount which the participant withdrew
+    // is `total_withdraw - total_withdraw_from_previous_event_or_zero`
+    /* event ChannelWithdraw(
+        uint256 indexed channel_identifier,
+        address indexed participant,
+        uint256 total_withdraw
+    ); */
+
+    event ChannelClosed(
+        uint256 indexed channel_identifier,
+        address indexed closing_participant,
+        uint256 indexed nonce
+    );
+
+    event ChannelUnlocked(
+        uint256 indexed channel_identifier,
+        address indexed participant,
+        address indexed partner,
+        bytes32 locksroot,
+        uint256 unlocked_amount,
+        uint256 returned_tokens
+    );
+
+    event NonClosingBalanceProofUpdated(
+        uint256 indexed channel_identifier,
+        address indexed closing_participant,
+        uint256 indexed nonce
+    );
+
+    event ChannelSettled(
+        uint256 indexed channel_identifier,
+        uint256 participant1_amount,
+        uint256 participant2_amount
+    );
+
+    modifier onlyDeprecationExecutor() {
+        require(msg.sender == deprecation_executor);
+        _;
+    }
+
+    modifier isSafe() {
+        require(safety_deprecation_switch == false);
+        _;
+    }
+
+    modifier isOpen(uint256 channel_identifier) {
+        require(channels[channel_identifier].state == ChannelState.Opened);
+        _;
+    }
+
+    modifier settleTimeoutValid(uint256 timeout) {
+        require(timeout >= settlement_timeout_min);
+        require(timeout <= settlement_timeout_max);
+        _;
+    }
+
+    constructor(
+        address _token_address,
+        address _secret_registry,
+        uint256 _chain_id,
+        uint256 _settlement_timeout_min,
+        uint256 _settlement_timeout_max,
+        address _deprecation_executor
+    )
+        public
+    {
+        require(_token_address != address(0x0));
+        require(_secret_registry != address(0x0));
+        require(_deprecation_executor != address(0x0));
+        require(_chain_id > 0);
+        require(_settlement_timeout_min > 0);
+        require(_settlement_timeout_max > _settlement_timeout_min);
+        require(contractExists(_token_address));
+        require(contractExists(_secret_registry));
+
+        token = Token(_token_address);
+
+        secret_registry = SecretRegistry(_secret_registry);
+        chain_id = _chain_id;
+        settlement_timeout_min = _settlement_timeout_min;
+        settlement_timeout_max = _settlement_timeout_max;
+
+        // Make sure the contract is indeed a token contract
+        require(token.totalSupply() > 0);
+
+        deprecation_executor = _deprecation_executor;
+    }
+
+    function deprecate() isSafe onlyDeprecationExecutor public {
+        safety_deprecation_switch = true;
+    }
+
+    /// @notice Opens a new channel between `participant1` and `participant2`.
+    /// Can be called by anyone.
+    /// @param participant1 Ethereum address of a channel participant.
+    /// @param participant2 Ethereum address of the other channel participant.
+    /// @param settle_timeout Number of blocks that need to be mined between a
+    /// call to closeChannel and settleChannel.
+    function openChannel(address participant1, address participant2, uint256 settle_timeout)
+        isSafe
+        settleTimeoutValid(settle_timeout)
+        public
+        returns (uint256)
+    {
+        bytes32 pair_hash;
+        uint256 channel_identifier;
+
+        // Red Eyes release token network limit
+        require(token.balanceOf(address(this)) < token_network_deposit_limit);
+
+        // First increment the counter
+        // There will never be a channel with channel_identifier == 0
+        channel_counter += 1;
+        channel_identifier = channel_counter;
+
+        pair_hash = getParticipantsHash(participant1, participant2);
+
+        // There must only be one channel opened between two participants at
+        // any moment in time.
+        require(participants_hash_to_channel_identifier[pair_hash] == 0);
+        participants_hash_to_channel_identifier[pair_hash] = channel_identifier;
+
+        Channel storage channel = channels[channel_identifier];
+
+        // We always increase the channel counter, therefore no channel data can already exist,
+        // corresponding to this channel_identifier. This check must never fail.
+        assert(channel.settle_block_number == 0);
+        assert(channel.state == ChannelState.NonExistent);
+
+        // Store channel information
+        channel.settle_block_number = settle_timeout;
+        channel.state = ChannelState.Opened;
+
+        emit ChannelOpened(
+            channel_identifier,
+            participant1,
+            participant2,
+            settle_timeout
+        );
+
+        return channel_identifier;
+    }
+
+    /// @notice Sets the channel participant total deposit value.
+    /// Can be called by anyone.
+    /// @param channel_identifier Identifier for the channel on which this
+    /// operation takes place.
+    /// @param participant Channel participant whose deposit is being set.
+    /// @param total_deposit The total amount of tokens that the participant
+    /// will have as a deposit.
+    /// @param partner Channel partner address, needed to compute the total
+    /// channel deposit.
+    function setTotalDeposit(
+        uint256 channel_identifier,
+        address participant,
+        uint256 total_deposit,
+        address partner
+    )
+        isSafe
+        isOpen(channel_identifier)
+        public
+    {
+        require(channel_identifier == getChannelIdentifier(participant, partner));
+        require(total_deposit > 0);
+        require(total_deposit <= channel_participant_deposit_limit);
+
+        uint256 added_deposit;
+        uint256 channel_deposit;
+
+        Channel storage channel = channels[channel_identifier];
+        Participant storage participant_state = channel.participants[participant];
+        Participant storage partner_state = channel.participants[partner];
+
+        // Calculate the actual amount of tokens that will be transferred
+        added_deposit = total_deposit - participant_state.deposit;
+
+        // The actual amount of tokens that will be transferred must be > 0
+        require(added_deposit > 0);
+
+        // Underflow check; we use <= because added_deposit == total_deposit for the first deposit
+
+        require(added_deposit <= total_deposit);
+
+        // This should never fail at this point. Added check for security, because we directly set
+        // the participant_state.deposit = total_deposit, while we transfer `added_deposit` tokens.
+        assert(participant_state.deposit + added_deposit == total_deposit);
+
+        // Red Eyes release token network limit
+        require(token.balanceOf(address(this)) + added_deposit <= token_network_deposit_limit);
+
+        // Update the participant's channel deposit
+        participant_state.deposit = total_deposit;
+
+        // Calculate the entire channel deposit, to avoid overflow
+        channel_deposit = participant_state.deposit + partner_state.deposit;
+        // Overflow check
+        require(channel_deposit >= participant_state.deposit);
+
+        emit ChannelNewDeposit(
+            channel_identifier,
+            participant,
+            participant_state.deposit
+        );
+
+        // Do the transfer
+        require(token.transferFrom(msg.sender, address(this), added_deposit));
+    }
+
+    /* /// @notice Allows `participant` to withdraw tokens from the channel that he
+    /// has with `partner`, without closing it. Can be called by anyone. Can
+    /// only be called once per each signed withdraw message.
+    /// @param channel_identifier Identifier for the channel on which this
+    /// operation takes place.
+    /// @param participant Channel participant, who will receive the withdrawn
+    /// amount.
+    /// @param total_withdraw Total amount of tokens that are marked as
+    /// withdrawn from the channel during the channel lifecycle.
+    /// @param participant_signature Participant's signature on the withdraw
+    /// data.
+    /// @param partner_signature Partner's signature on the withdraw data.
+    function setTotalWithdraw(
+        uint256 channel_identifier,
+        address participant,
+        uint256 total_withdraw,
+        bytes participant_signature,
+        bytes partner_signature
+    )
+        isOpen(channel_identifier)
+        external
+    {
+        uint256 total_deposit;
+        uint256 current_withdraw;
+        address partner;
+
+        require(total_withdraw > 0);
+
+        // Authenticate both channel partners via there signatures:
+        require(participant == recoverAddressFromWithdrawMessage(
+            channel_identifier,
+            participant,
+            total_withdraw,
+            participant_signature
+        ));
+        partner = recoverAddressFromWithdrawMessage(
+            channel_identifier,
+            participant,
+            total_withdraw,
+            partner_signature
+        );
+
+        // Validate that authenticated partners and the channel identifier match
+        require(channel_identifier == getChannelIdentifier(participant, partner));
+
+        // Read channel state after validating the function input
+        Channel storage channel = channels[channel_identifier];
+        Participant storage participant_state = channel.participants[participant];
+        Participant storage partner_state = channel.participants[partner];
+
+        total_deposit = participant_state.deposit + partner_state.deposit;
+
+        // Entire withdrawn amount must not be bigger than the current channel deposit
+        require((total_withdraw + partner_state.withdrawn_amount) <= total_deposit);
+        require(total_withdraw <= (total_withdraw + partner_state.withdrawn_amount));
+
+        // Using the total_withdraw (monotonically increasing) in the signed
+        // message ensures that we do not allow replay attack to happen, by
+        // using the same withdraw proof twice.
+        // Next two lines enforce the monotonicity of total_withdraw and check for an underflow:
+        // (we use <= because current_withdraw == total_withdraw for the first withdraw)
+        current_withdraw = total_withdraw - participant_state.withdrawn_amount;
+        require(current_withdraw <= total_withdraw);
+
+        // The actual amount of tokens that will be transferred must be > 0 to disable the reuse of
+        // withdraw messages completely.
+        require(current_withdraw > 0);
+
+        // This should never fail at this point. Added check for security, because we directly set
+        // the participant_state.withdrawn_amount = total_withdraw,
+        // while we transfer `current_withdraw` tokens.
+        assert(participant_state.withdrawn_amount + current_withdraw == total_withdraw);
+
+        emit ChannelWithdraw(
+            channel_identifier,
+            participant,
+            total_withdraw
+        );
+
+        // Do the state change and tokens transfer
+        participant_state.withdrawn_amount = total_withdraw;
+        require(token.transfer(participant, current_withdraw));
+
+        // This should never happen, as we have an overflow check in setTotalDeposit
+        assert(total_deposit >= participant_state.deposit);
+        assert(total_deposit >= partner_state.deposit);
+
+        // A withdraw should never happen if a participant already has a
+        // balance proof in storage. This should never fail as we use isOpen.
+        assert(participant_state.nonce == 0);
+        assert(partner_state.nonce == 0);
+
+    } */
+
+    /// @notice Close the channel defined by the two participant addresses. Only
+    /// a participant may close the channel, providing a balance proof signed by
+    /// its partner. Callable only once.
+    /// @param channel_identifier Identifier for the channel on which this
+    /// operation takes place.
+    /// @param partner Channel partner of the `msg.sender`, who provided the
+    /// signature.
+    /// @param balance_hash Hash of (transferred_amount, locked_amount,
+    /// locksroot).
+    /// @param additional_hash Computed from the message. Used for message
+    /// authentication.
+    /// @param nonce Strictly monotonic value used to order transfers.
+    /// @param signature Partner's signature of the balance proof data.
+    function closeChannel(
+        uint256 channel_identifier,
+        address partner,
+        bytes32 balance_hash,
+        uint256 nonce,
+        bytes32 additional_hash,
+        bytes memory signature
+    )
+        isOpen(channel_identifier)
+        public
+    {
+        require(channel_identifier == getChannelIdentifier(msg.sender, partner));
+
+        address recovered_partner_address;
+
+        Channel storage channel = channels[channel_identifier];
+
+        channel.state = ChannelState.Closed;
+        channel.participants[msg.sender].is_the_closer = true;
+
+        // This is the block number at which the channel can be settled.
+        channel.settle_block_number += uint256(block.number);
+
+        // Nonce 0 means that the closer never received a transfer, therefore
+        // never received a balance proof, or he is intentionally not providing
+        // the latest transfer, in which case the closing party is going to
+        // lose the tokens that were transferred to him.
+        if (nonce > 0) {
+            recovered_partner_address = recoverAddressFromBalanceProof(
+                channel_identifier,
+                balance_hash,
+                nonce,
+                additional_hash,
+                signature
+            );
+            // Signature must be from the channel partner
+            require(partner == recovered_partner_address);
+
+            updateBalanceProofData(
+                channel,
+                recovered_partner_address,
+                nonce,
+                balance_hash
+            );
+        }
+
+        emit ChannelClosed(channel_identifier, msg.sender, nonce);
+    }
+
+    /// @notice Called on a closed channel, the function allows the non-closing
+    /// participant to provide the last balance proof, which modifies the
+    /// closing participant's state. Can be called multiple times by anyone.
+    /// @param channel_identifier Identifier for the channel on which this
+    /// operation takes place.
+    /// @param closing_participant Channel participant who closed the channel.
+    /// @param non_closing_participant Channel participant who needs to update
+    /// the balance proof.
+    /// @param balance_hash Hash of (transferred_amount, locked_amount,
+    /// locksroot).
+    /// @param additional_hash Computed from the message. Used for message
+    /// authentication.
+    /// @param nonce Strictly monotonic value used to order transfers.
+    /// @param closing_signature Closing participant's signature of the balance
+    /// proof data.
+    /// @param non_closing_signature Non-closing participant signature of the
+    /// balance proof data.
+    function updateNonClosingBalanceProof(
+        uint256 channel_identifier,
+        address closing_participant,
+        address non_closing_participant,
+        bytes32 balance_hash,
+        uint256 nonce,
+        bytes32 additional_hash,
+        bytes calldata closing_signature,
+        bytes calldata non_closing_signature
+    )
+        external
+    {
+        require(channel_identifier == getChannelIdentifier(
+            closing_participant,
+            non_closing_participant
+        ));
+        require(balance_hash != bytes32(0x0));
+        require(nonce > 0);
+
+        address recovered_non_closing_participant;
+        address recovered_closing_participant;
+
+        Channel storage channel = channels[channel_identifier];
+
+        require(channel.state == ChannelState.Closed);
+
+        // Calling this function after the settlement window is forbidden to
+        // fix the following race condition:
+        //
+        // 1 A badly configured node A, that doesn't have a monitoring service
+        //   and is temporarily offline does not call update during the
+        //   settlement window.
+        // 2 The well behaved partner B, who called close, sees the
+        //   settlement window is over and calls settle. At this point the B's
+        //   balance proofs which should be provided by A is missing, so B will
+        //   call settle with its balance proof zeroed out.
+        // 3 A restarts and calls update, which will change B's balance
+        //   proof.
+        // 4 At this point, the transactions from 2 and 3 are racing, and one
+        //   of them will fail.
+        //
+        // To avoid the above race condition, which would require special
+        // handling on both nodes, the call to update is forbidden after the
+        // settlement window. This does not affect safety, since we assume the
+        // nodes are always properly configured and have a monitoring service
+        // available to call update on the user's behalf.
+        require(channel.settle_block_number >= block.number);
+
+        // We need the signature from the non-closing participant to allow
+        // anyone to make this transaction. E.g. a monitoring service.
+        recovered_non_closing_participant = recoverAddressFromBalanceProofUpdateMessage(
+            channel_identifier,
+            balance_hash,
+            nonce,
+            additional_hash,
+            closing_signature,
+            non_closing_signature
+        );
+        require(non_closing_participant == recovered_non_closing_participant);
+
+        recovered_closing_participant = recoverAddressFromBalanceProof(
+            channel_identifier,
+            balance_hash,
+            nonce,
+            additional_hash,
+            closing_signature
+        );
+        require(closing_participant == recovered_closing_participant);
+
+        Participant storage closing_participant_state = channel.participants[closing_participant];
+        // Make sure the first signature is from the closing participant
+        require(closing_participant_state.is_the_closer);
+
+        // Update the balance proof data for the closing_participant
+        updateBalanceProofData(channel, closing_participant, nonce, balance_hash);
+
+        emit NonClosingBalanceProofUpdated(
+            channel_identifier,
+            closing_participant,
+            nonce
+        );
+    }
+
+    /// @notice Settles the balance between the two parties. Note that arguments
+    /// order counts: `participant1_transferred_amount +
+    /// participant1_locked_amount` <= `participant2_transferred_amount +
+    /// participant2_locked_amount`
+    /// @param channel_identifier Identifier for the channel on which this
+    /// operation takes place.
+    /// @param participant1 Channel participant.
+    /// @param participant1_transferred_amount The latest known amount of tokens
+    /// transferred from `participant1` to `participant2`.
+    /// @param participant1_locked_amount Amount of tokens owed by
+    /// `participant1` to `participant2`, contained in locked transfers that
+    /// will be retrieved by calling `unlock` after the channel is settled.
+    /// @param participant1_locksroot The latest known merkle root of the
+    /// pending hash-time locks of `participant1`, used to validate the unlocked
+    /// proofs.
+    /// @param participant2 Other channel participant.
+    /// @param participant2_transferred_amount The latest known amount of tokens
+    /// transferred from `participant2` to `participant1`.
+    /// @param participant2_locked_amount Amount of tokens owed by
+    /// `participant2` to `participant1`, contained in locked transfers that
+    /// will be retrieved by calling `unlock` after the channel is settled.
+    /// @param participant2_locksroot The latest known merkle root of the
+    /// pending hash-time locks of `participant2`, used to validate the unlocked
+    /// proofs.
+    function settleChannel(
+        uint256 channel_identifier,
+        address participant1,
+        uint256 participant1_transferred_amount,
+        uint256 participant1_locked_amount,
+        bytes32 participant1_locksroot,
+        address participant2,
+        uint256 participant2_transferred_amount,
+        uint256 participant2_locked_amount,
+        bytes32 participant2_locksroot
+    )
+        public
+    {
+        // There are several requirements that this function MUST enforce:
+        // - it MUST never fail; therefore, any overflows or underflows must be
+        // handled gracefully
+        // - it MUST ensure that if participants use the latest valid balance proofs,
+        // provided by the official Raiden client, the participants will be able
+        // to receive correct final balances at the end of the channel lifecycle
+        // - it MUST ensure that the participants cannot cheat by providing an
+        // old, valid balance proof of their partner; meaning that their partner MUST
+        // receive at least the amount of tokens that he would have received if
+        // the latest valid balance proofs are used.
+        // - the contract cannot determine if a balance proof is invalid (values
+        // are not within the constraints enforced by the official Raiden client),
+        // therefore it cannot ensure correctness. Users MUST use the official
+        // Raiden clients for signing balance proofs.
+
+        require(channel_identifier == getChannelIdentifier(participant1, participant2));
+
+        bytes32 pair_hash;
+
+        pair_hash = getParticipantsHash(participant1, participant2);
+        Channel storage channel = channels[channel_identifier];
+
+        require(channel.state == ChannelState.Closed);
+
+        // Settlement window must be over
+        require(channel.settle_block_number < block.number);
+
+        Participant storage participant1_state = channel.participants[participant1];
+        Participant storage participant2_state = channel.participants[participant2];
+
+        require(verifyBalanceHashData(
+            participant1_state,
+            participant1_transferred_amount,
+            participant1_locked_amount,
+            participant1_locksroot
+        ));
+
+        require(verifyBalanceHashData(
+            participant2_state,
+            participant2_transferred_amount,
+            participant2_locked_amount,
+            participant2_locksroot
+        ));
+
+        // We are calculating the final token amounts that need to be
+        // transferred to the participants now and the amount of tokens that
+        // need to remain locked in the contract. These tokens can be unlocked
+        // by calling `unlock`.
+        // participant1_transferred_amount = the amount of tokens that
+        //   participant1 will receive in this transaction.
+        // participant2_transferred_amount = the amount of tokens that
+        //   participant2 will receive in this transaction.
+        // participant1_locked_amount = the amount of tokens remaining in the
+        //   contract, representing pending transfers from participant1 to participant2.
+        // participant2_locked_amount = the amount of tokens remaining in the
+        //   contract, representing pending transfers from participant2 to participant1.
+        // We are reusing variables due to the local variables number limit.
+        // For better readability this can be refactored further.
+        (
+            participant1_transferred_amount,
+            participant2_transferred_amount,
+            participant1_locked_amount,
+            participant2_locked_amount
+        ) = getSettleTransferAmounts(
+            participant1_state,
+            participant1_transferred_amount,
+            participant1_locked_amount,
+            participant2_state,
+            participant2_transferred_amount,
+            participant2_locked_amount
+        );
+
+        // Remove the channel data from storage
+        delete channel.participants[participant1];
+        delete channel.participants[participant2];
+        delete channels[channel_identifier];
+
+        // Remove the pair's channel counter
+        delete participants_hash_to_channel_identifier[pair_hash];
+
+        // Store balance data needed for `unlock`, including the calculated
+        // locked amounts remaining in the contract.
+        storeUnlockData(
+            channel_identifier,
+            participant1,
+            participant2,
+            participant1_locked_amount,
+            participant1_locksroot
+        );
+        storeUnlockData(
+            channel_identifier,
+            participant2,
+            participant1,
+            participant2_locked_amount,
+            participant2_locksroot
+        );
+
+        emit ChannelSettled(
+            channel_identifier,
+            participant1_transferred_amount,
+            participant2_transferred_amount
+        );
+
+        // Do the actual token transfers
+        if (participant1_transferred_amount > 0) {
+            require(token.transfer(participant1, participant1_transferred_amount));
+        }
+
+        if (participant2_transferred_amount > 0) {
+            require(token.transfer(participant2, participant2_transferred_amount));
+        }
+    }
+
+    /// @notice Unlocks all pending off-chain transfers from `partner` to
+    /// `participant` and sends the locked tokens corresponding to locks with
+    /// secrets registered on-chain to the `participant`. Locked tokens
+    /// corresponding to locks where the secret was not revealed on-chain will
+    /// return to the `partner`. Anyone can call unlock.
+    /// @param channel_identifier Identifier for the channel on which this
+    /// operation takes place.
+    /// @param participant Address who will receive the claimable unlocked
+    /// tokens.
+    /// @param partner Address who sent the pending transfers and will receive
+    /// the unclaimable unlocked tokens.
+    /// @param merkle_tree_leaves The entire merkle tree of pending transfers
+    /// that `partner` sent to `participant`.
+    function unlock(
+        uint256 channel_identifier,
+        address participant,
+        address partner,
+        bytes memory merkle_tree_leaves
+    )
+        public
+    {
+        // Channel represented by channel_identifier must be settled and
+        // channel data deleted
+        require(channel_identifier != getChannelIdentifier(participant, partner));
+
+        // After the channel is settled the storage is cleared, therefore the
+        // value will be NonExistent and not Settled. The value Settled is used
+        // for the external APIs
+        require(channels[channel_identifier].state == ChannelState.NonExistent);
+
+        require(merkle_tree_leaves.length > 0);
+
+        bytes32 unlock_key;
+        bytes32 computed_locksroot;
+        uint256 unlocked_amount;
+        uint256 locked_amount;
+        uint256 returned_tokens;
+
+        // Calculate the locksroot for the pending transfers and the amount of
+        // tokens corresponding to the locked transfers with secrets revealed
+        // on chain.
+        (computed_locksroot, unlocked_amount) = getMerkleRootAndUnlockedAmount(
+            merkle_tree_leaves
+        );
+
+        // The partner must have a non-empty locksroot on-chain that must be
+        // the same as the computed locksroot.
+        // Get the amount of tokens that have been left in the contract, to
+        // account for the pending transfers `partner` -> `participant`.
+        unlock_key = getUnlockIdentifier(channel_identifier, partner, participant);
+        UnlockData storage unlock_data = unlock_identifier_to_unlock_data[unlock_key];
+        locked_amount = unlock_data.locked_amount;
+
+        // Locksroot must be the same as the computed locksroot
+        require(unlock_data.locksroot == computed_locksroot);
+
+        // There are no pending transfers if the locked_amount is 0.
+        // Transaction must fail
+        require(locked_amount > 0);
+
+        // Make sure we don't transfer more tokens than previously reserved in
+        // the smart contract.
+        unlocked_amount = min(unlocked_amount, locked_amount);
+
+        // Transfer the rest of the tokens back to the partner
+        returned_tokens = locked_amount - unlocked_amount;
+
+        // Remove partner's unlock data
+        delete unlock_identifier_to_unlock_data[unlock_key];
+
+        emit ChannelUnlocked(
+            channel_identifier,
+            participant,
+            partner,
+            computed_locksroot,
+            unlocked_amount,
+            returned_tokens
+        );
+
+        // Transfer the unlocked tokens to the participant. unlocked_amount can
+        // be 0
+        if (unlocked_amount > 0) {
+            require(token.transfer(participant, unlocked_amount));
+        }
+
+        // Transfer the rest of the tokens back to the partner
+        if (returned_tokens > 0) {
+            require(token.transfer(partner, returned_tokens));
+        }
+
+        // At this point, this should always be true
+        assert(locked_amount >= returned_tokens);
+        assert(locked_amount >= unlocked_amount);
+    }
+
+    /* /// @notice Cooperatively settles the balances between the two channel
+    /// participants and transfers the agreed upon token amounts to the
+    /// participants. After this the channel lifecycle has ended and no more
+    /// operations can be done on it.
+    /// @param channel_identifier Identifier for the channel on which this
+    /// operation takes place.
+    /// @param participant1_address Address of channel participant.
+    /// @param participant1_balance Amount of tokens that `participant1_address`
+    /// must receive when the channel is settled and removed.
+    /// @param participant2_address Address of the other channel participant.
+    /// @param participant2_balance Amount of tokens that `participant2_address`
+    /// must receive when the channel is settled and removed.
+    /// @param participant1_signature Signature of `participant1_address` on the
+    /// cooperative settle message.
+    /// @param participant2_signature Signature of `participant2_address` on the
+    /// cooperative settle message.
+    function cooperativeSettle(
+        uint256 channel_identifier,
+        address participant1_address,
+        uint256 participant1_balance,
+        address participant2_address,
+        uint256 participant2_balance,
+        bytes participant1_signature,
+        bytes participant2_signature
+    )
+        public
+    {
+        require(channel_identifier == getChannelIdentifier(
+            participant1_address,
+            participant2_address
+        ));
+        bytes32 pair_hash;
+        address participant1;
+        address participant2;
+        uint256 total_available_deposit;
+
+        pair_hash = getParticipantsHash(participant1_address, participant2_address);
+        Channel storage channel = channels[channel_identifier];
+
+        require(channel.state == ChannelState.Opened);
+
+        participant1 = recoverAddressFromCooperativeSettleSignature(
+            channel_identifier,
+            participant1_address,
+            participant1_balance,
+            participant2_address,
+            participant2_balance,
+            participant1_signature
+        );
+        // The provided address must be the same as the recovered one
+        require(participant1 == participant1_address);
+
+        participant2 = recoverAddressFromCooperativeSettleSignature(
+            channel_identifier,
+            participant1_address,
+            participant1_balance,
+            participant2_address,
+            participant2_balance,
+            participant2_signature
+        );
+        // The provided address must be the same as the recovered one
+        require(participant2 == participant2_address);
+
+        Participant storage participant1_state = channel.participants[participant1];
+        Participant storage participant2_state = channel.participants[participant2];
+
+        total_available_deposit = getChannelAvailableDeposit(
+            participant1_state,
+            participant2_state
+        );
+        // The sum of the provided balances must be equal to the total
+        // available deposit
+        require(total_available_deposit == (participant1_balance + participant2_balance));
+        // Overflow check for the balances addition from the above check.
+        // This overflow should never happen if the token.transfer function is implemented
+        // correctly. We do not control the token implementation, therefore we add this
+        // check for safety.
+        require(participant1_balance <= participant1_balance + participant2_balance);
+
+        // Remove channel data from storage before doing the token transfers
+        delete channel.participants[participant1];
+        delete channel.participants[participant2];
+        delete channels[channel_identifier];
+
+        // Remove the pair's channel counter
+        delete participants_hash_to_channel_identifier[pair_hash];
+
+        emit ChannelSettled(channel_identifier, participant1_balance, participant2_balance);
+
+        // Do the token transfers
+        if (participant1_balance > 0) {
+            require(token.transfer(participant1, participant1_balance));
+        }
+
+        if (participant2_balance > 0) {
+            require(token.transfer(participant2, participant2_balance));
+        }
+    } */
+
+    /// @notice Returns the unique identifier for the channel given by the
+    /// contract.
+    /// @param participant Address of a channel participant.
+    /// @param partner Address of the other channel participant.
+    /// @return Unique identifier for the channel. It can be 0 if channel does
+    /// not exist.
+    function getChannelIdentifier(address participant, address partner)
+        view
+        public
+        returns (uint256)
+    {
+        require(participant != address(0x0));
+        require(partner != address(0x0));
+        require(participant != partner);
+
+        bytes32 pair_hash = getParticipantsHash(participant, partner);
+        return participants_hash_to_channel_identifier[pair_hash];
+    }
+
+    /// @dev Returns the channel specific data.
+    /// @param channel_identifier Identifier for the channel on which this
+    /// operation takes place.
+    /// @param participant1 Address of a channel participant.
+    /// @param participant2 Address of the other channel participant.
+    /// @return Channel settle_block_number and state.
+    function getChannelInfo(
+        uint256 channel_identifier,
+        address participant1,
+        address participant2
+    )
+        view
+        external
+        returns (uint256, ChannelState)
+    {
+        bytes32 unlock_key1;
+        bytes32 unlock_key2;
+
+        Channel storage channel = channels[channel_identifier];
+        ChannelState state = channel.state;  // This must **not** update the storage
+
+        if (state == ChannelState.NonExistent &&
+            channel_identifier > 0 &&
+            channel_identifier <= channel_counter
+        ) {
+            // The channel has been settled, channel data is removed Therefore,
+            // the channel state in storage is actually `0`, or `NonExistent`
+            // However, for this view function, we return `Settled`, in order
+            // to provide a consistent external API
+            state = ChannelState.Settled;
+
+            // We might still have data stored for future unlock operations
+            // Only if we do not, we can consider the channel as `Removed`
+            unlock_key1 = getUnlockIdentifier(channel_identifier, participant1, participant2);
+            UnlockData storage unlock_data1 = unlock_identifier_to_unlock_data[unlock_key1];
+
+            unlock_key2 = getUnlockIdentifier(channel_identifier, participant2, participant1);
+            UnlockData storage unlock_data2 = unlock_identifier_to_unlock_data[unlock_key2];
+
+            if (unlock_data1.locked_amount == 0 && unlock_data2.locked_amount == 0) {
+                state = ChannelState.Removed;
+            }
+        }
+
+        return (
+            channel.settle_block_number,
+            state
+        );
+    }
+
+    /// @dev Returns the channel specific data.
+    /// @param channel_identifier Identifier for the channel on which this
+    /// operation takes place.
+    /// @param participant Address of the channel participant whose data will be
+    /// returned.
+    /// @param partner Address of the channel partner.
+    /// @return Participant's deposit, withdrawn_amount, whether the participant
+    /// has called `closeChannel` or not, balance_hash, nonce, locksroot,
+    /// locked_amount.
+    function getChannelParticipantInfo(
+            uint256 channel_identifier,
+            address participant,
+            address partner
+    )
+        view
+        external
+        returns (uint256, uint256, bool, bytes32, uint256, bytes32, uint256)
+    {
+        bytes32 unlock_key;
+
+        Participant storage participant_state = channels[channel_identifier].participants[
+            participant
+        ];
+        unlock_key = getUnlockIdentifier(channel_identifier, participant, partner);
+        UnlockData storage unlock_data = unlock_identifier_to_unlock_data[unlock_key];
+
+        return (
+            participant_state.deposit,
+            participant_state.withdrawn_amount,
+            participant_state.is_the_closer,
+            participant_state.balance_hash,
+            participant_state.nonce,
+            unlock_data.locksroot,
+            unlock_data.locked_amount
+        );
+    }
+
+    /// @dev Get the hash of the participant addresses, ordered
+    /// lexicographically.
+    /// @param participant Address of a channel participant.
+    /// @param partner Address of the other channel participant.
+    function getParticipantsHash(address participant, address partner)
+        pure
+        public
+        returns (bytes32)
+    {
+        require(participant != address(0x0));
+        require(partner != address(0x0));
+        require(participant != partner);
+
+        if (participant < partner) {
+            return keccak256(abi.encodePacked(participant, partner));
+        } else {
+            return keccak256(abi.encodePacked(partner, participant));
+        }
+    }
+
+    /// @dev Get the hash of the channel identifier and the participant
+    /// addresses (whose ordering matters). The hash might be useful for
+    /// the partner to look up the appropriate UnlockData to claim.
+    /// @param channel_identifier Identifier for the channel which the
+    /// UnlockData is about.
+    /// @param participant Sender of the pending transfers that the UnlockData
+    /// represents.
+    /// @param partner Receiver of the pending transfers that the UnlockData
+    /// represents.
+    function getUnlockIdentifier(
+        uint256 channel_identifier,
+        address participant,
+        address partner
+    )
+        pure
+        public
+        returns (bytes32)
+    {
+        require(participant != partner);
+        return keccak256(abi.encodePacked(channel_identifier, participant, partner));
+    }
+
+    function updateBalanceProofData(
+        Channel storage channel,
+        address participant,
+        uint256 nonce,
+        bytes32 balance_hash
+    )
+        internal
+    {
+        Participant storage participant_state = channel.participants[participant];
+
+        // Multiple calls to updateNonClosingBalanceProof can be made and we
+        // need to store the last known balance proof data
+        require(nonce > participant_state.nonce);
+
+        participant_state.nonce = nonce;
+        participant_state.balance_hash = balance_hash;
+    }
+
+    function storeUnlockData(
+        uint256 channel_identifier,
+        address participant,
+        address partner,
+        uint256 locked_amount,
+        bytes32 locksroot
+    )
+        internal
+    {
+        // If there are transfers to unlock, store the locksroot and total
+        // amount of tokens
+        if (locked_amount == 0 || locksroot == 0) {
+            return;
+        }
+
+        bytes32 key = getUnlockIdentifier(channel_identifier, participant, partner);
+        UnlockData storage unlock_data = unlock_identifier_to_unlock_data[key];
+        unlock_data.locksroot = locksroot;
+        unlock_data.locked_amount = locked_amount;
+    }
+
+    function getChannelAvailableDeposit(
+        Participant storage participant1_state,
+        Participant storage participant2_state
+    )
+        view
+        internal
+        returns (uint256 total_available_deposit)
+    {
+        total_available_deposit = (
+            participant1_state.deposit +
+            participant2_state.deposit -
+            participant1_state.withdrawn_amount -
+            participant2_state.withdrawn_amount
+        );
+    }
+
+    /// @dev Function that calculates the amount of tokens that the participants
+    /// will receive when calling settleChannel.
+    /// Check https://github.com/raiden-network/raiden-contracts/issues/188 for the settlement
+    /// algorithm analysis and explanations.
+    function getSettleTransferAmounts(
+        Participant storage participant1_state,
+        uint256 participant1_transferred_amount,
+        uint256 participant1_locked_amount,
+        Participant storage participant2_state,
+        uint256 participant2_transferred_amount,
+        uint256 participant2_locked_amount
+    )
+        view
+        private
+        returns (uint256, uint256, uint256, uint256)
+    {
+        // The scope of this function is to compute the settlement amounts that
+        // the two channel participants will receive when calling settleChannel
+        // and the locked amounts that remain in the contract, to account for
+        // the pending, not finalized transfers, that will be received by the
+        // participants when calling `unlock`.
+
+        // The amount of tokens that participant1 MUST receive at the end of
+        // the channel lifecycle (after settleChannel and unlock) is:
+        // B1 = D1 - W1 + T2 - T1 + Lc2 - Lc1
+
+        // The amount of tokens that participant2 MUST receive at the end of
+        // the channel lifecycle (after settleChannel and unlock) is:
+        // B2 = D2 - W2 + T1 - T2 + Lc1 - Lc2
+
+        // B1 + B2 = TAD = D1 + D2 - W1 - W2
+        // TAD = total available deposit at settlement time
+
+        // L1 = Lc1 + Lu1
+        // L2 = Lc2 + Lu2
+
+        // where:
+        // B1 = final balance of participant1 after the channel is removed
+        // D1 = total amount deposited by participant1 into the channel
+        // W1 = total amount withdrawn by participant1 from the channel
+        // T2 = total amount transferred by participant2 to participant1 (finalized transfers)
+        // T1 = total amount transferred by participant1 to participant2 (finalized transfers)
+        // L1 = total amount of tokens locked in pending transfers, sent by
+        //   participant1 to participant2
+        // L2 = total amount of tokens locked in pending transfers, sent by
+        //   participant2 to participant1
+        // Lc2 = the amount that can be claimed by participant1 from the pending
+        //   transfers (that have not been finalized off-chain), sent by
+        //   participant2 to participant1. These are part of the locked amount
+        //   value from participant2's balance proof. They are considered claimed
+        //   if the secret corresponding to these locked transfers was registered
+        //   on-chain, in the SecretRegistry contract, before the lock's expiration.
+        // Lu1 = unclaimable locked amount from L1
+        // Lc1 = the amount that can be claimed by participant2 from the pending
+        //   transfers (that have not been finalized off-chain),
+        //   sent by participant1 to participant2
+        // Lu2 = unclaimable locked amount from L2
+
+        // Notes:
+        // 1) The unclaimble tokens from a locked amount will return to the sender.
+        // At the time of calling settleChannel, the TokenNetwork contract does
+        // not know what locked amounts are claimable or unclaimable.
+        // 2) There are some Solidity constraints that make the calculations
+        // more difficult: attention to overflows and underflows, that MUST be
+        // handled without throwing.
+
+        // Cases that require attention:
+        // case1. If participant1 does NOT provide a balance proof or provides
+        // an old balance proof.  participant2_transferred_amount can be [0,
+        // real_participant2_transferred_amount) We MUST NOT punish
+        // participant2.
+        // case2. If participant2 does NOT provide a balance proof or provides
+        // an old balance proof.  participant1_transferred_amount can be [0,
+        // real_participant1_transferred_amount) We MUST NOT punish
+        // participant1.
+        // case3. If neither participants provide a balance proof, we just
+        // subtract their withdrawn amounts from their deposits.
+
+        // This is why, the algorithm implemented in Solidity is:
+        // (explained at each step, below)
+        // RmaxP1 = (T2 + L2) - (T1 + L1) + D1 - W1
+        // RmaxP1 = min(TAD, RmaxP1)
+        // RmaxP2 = TAD - RmaxP1
+        // SL2 = min(RmaxP1, L2)
+        // S1 = RmaxP1 - SL2
+        // SL1 = min(RmaxP2, L1)
+        // S2 = RmaxP2 - SL1
+
+        // where:
+        // RmaxP1 = due to possible over/underflows that only appear when using
+        //    old balance proofs & the fact that settlement balance calculation
+        //    is symmetric (we can calculate either RmaxP1 and RmaxP2 first,
+        //    order does not affect result), this is a convention used to determine
+        //    the maximum receivable amount of participant1 at settlement time
+        // S1 = amount received by participant1 when calling settleChannel
+        // SL1 = the maximum amount from L1 that can be locked in the
+        //   TokenNetwork contract when calling settleChannel (due to overflows
+        //   that only happen when using old balance proofs)
+        // S2 = amount received by participant2 when calling settleChannel
+        // SL2 = the maximum amount from L2 that can be locked in the
+        //   TokenNetwork contract when calling settleChannel (due to overflows
+        //   that only happen when using old balance proofs)
+
+        uint256 participant1_amount;
+        uint256 participant2_amount;
+        uint256 total_available_deposit;
+
+        SettlementData memory participant1_settlement;
+        SettlementData memory participant2_settlement;
+
+        participant1_settlement.deposit = participant1_state.deposit;
+        participant1_settlement.withdrawn = participant1_state.withdrawn_amount;
+        participant1_settlement.transferred = participant1_transferred_amount;
+        participant1_settlement.locked = participant1_locked_amount;
+
+        participant2_settlement.deposit = participant2_state.deposit;
+        participant2_settlement.withdrawn = participant2_state.withdrawn_amount;
+        participant2_settlement.transferred = participant2_transferred_amount;
+        participant2_settlement.locked = participant2_locked_amount;
+
+        // TAD = D1 + D2 - W1 - W2 = total available deposit at settlement time
+        total_available_deposit = getChannelAvailableDeposit(
+            participant1_state,
+            participant2_state
+        );
+
+        // RmaxP1 = (T2 + L2) - (T1 + L1) + D1 - W1
+        // This amount is the maximum possible amount that participant1 can
+        // receive at settlement time and also contains the entire locked amount
+        //  of the pending transfers from participant2 to participant1.
+        participant1_amount = getMaxPossibleReceivableAmount(
+            participant1_settlement,
+            participant2_settlement
+        );
+
+        // RmaxP1 = min(TAD, RmaxP1)
+        // We need to bound this to the available channel deposit in order to
+        // not send tokens from other channels. The only case where TAD is
+        // smaller than RmaxP1 is when at least one balance proof is old.
+        participant1_amount = min(participant1_amount, total_available_deposit);
+
+        // RmaxP2 = TAD - RmaxP1
+        // Now it is safe to subtract without underflow
+        participant2_amount = total_available_deposit - participant1_amount;
+
+        // SL2 = min(RmaxP1, L2)
+        // S1 = RmaxP1 - SL2
+        // Both operations are done by failsafe_subtract
+        // We take out participant2's pending transfers locked amount, bounding
+        // it by the maximum receivable amount of participant1
+        (participant1_amount, participant2_locked_amount) = failsafe_subtract(
+            participant1_amount,
+            participant2_locked_amount
+        );
+
+        // SL1 = min(RmaxP2, L1)
+        // S2 = RmaxP2 - SL1
+        // Both operations are done by failsafe_subtract
+        // We take out participant1's pending transfers locked amount, bounding
+        // it by the maximum receivable amount of participant2
+        (participant2_amount, participant1_locked_amount) = failsafe_subtract(
+            participant2_amount,
+            participant1_locked_amount
+        );
+
+        // This should never throw:
+        // S1 and S2 MUST be smaller than TAD
+        assert(participant1_amount <= total_available_deposit);
+        assert(participant2_amount <= total_available_deposit);
+        // S1 + S2 + SL1 + SL2 == TAD
+        assert(total_available_deposit == (
+            participant1_amount +
+            participant2_amount +
+            participant1_locked_amount +
+            participant2_locked_amount
+        ));
+
+        return (
+            participant1_amount,
+            participant2_amount,
+            participant1_locked_amount,
+            participant2_locked_amount
+        );
+    }
+
+    function getMaxPossibleReceivableAmount(
+        SettlementData memory participant1_settlement,
+        SettlementData memory participant2_settlement
+    )
+        pure
+        internal
+        returns (uint256)
+    {
+        uint256 participant1_max_transferred;
+        uint256 participant2_max_transferred;
+        uint256 participant1_net_max_received;
+        uint256 participant1_max_amount;
+
+        // This is the maximum possible amount that participant1 could transfer
+        // to participant2, if all the pending lock secrets have been
+        // registered
+        participant1_max_transferred = failsafe_addition(
+            participant1_settlement.transferred,
+            participant1_settlement.locked
+        );
+
+        // This is the maximum possible amount that participant2 could transfer
+        // to participant1, if all the pending lock secrets have been
+        // registered
+        participant2_max_transferred = failsafe_addition(
+            participant2_settlement.transferred,
+            participant2_settlement.locked
+        );
+
+        // We enforce this check artificially, in order to get rid of hard
+        // to deal with over/underflows. Settlement balance calculation is
+        // symmetric (we can calculate either RmaxP1 and RmaxP2 first, order does
+        // not affect result). This means settleChannel must be called with
+        // ordered values.
+        require(participant2_max_transferred >= participant1_max_transferred);
+
+        assert(participant1_max_transferred >= participant1_settlement.transferred);
+        assert(participant2_max_transferred >= participant2_settlement.transferred);
+
+        // This is the maximum amount that participant1 can receive at settlement time
+        participant1_net_max_received = (
+            participant2_max_transferred -
+            participant1_max_transferred
+        );
+
+        // Next, we add the participant1's deposit and subtract the already
+        // withdrawn amount
+        participant1_max_amount = failsafe_addition(
+            participant1_net_max_received,
+            participant1_settlement.deposit
+        );
+
+        // Subtract already withdrawn amount
+        (participant1_max_amount, ) = failsafe_subtract(
+            participant1_max_amount,
+            participant1_settlement.withdrawn
+        );
+        return participant1_max_amount;
+    }
+
+    function verifyBalanceHashData(
+        Participant storage participant,
+        uint256 transferred_amount,
+        uint256 locked_amount,
+        bytes32 locksroot
+    )
+        view
+        internal
+        returns (bool)
+    {
+        // When no balance proof has been provided, we need to check this
+        // separately because hashing values of 0 outputs a value != 0
+        if (participant.balance_hash == 0 &&
+            transferred_amount == 0 &&
+            locked_amount == 0 &&
+            locksroot == 0
+        ) {
+            return true;
+        }
+
+        // Make sure the hash of the provided state is the same as the stored
+        // balance_hash
+        return participant.balance_hash == keccak256(abi.encodePacked(
+            transferred_amount,
+            locked_amount,
+            locksroot
+        ));
+    }
+
+    function recoverAddressFromBalanceProof(
+        uint256 channel_identifier,
+        bytes32 balance_hash,
+        uint256 nonce,
+        bytes32 additional_hash,
+        bytes memory signature
+    )
+        view
+        internal
+        returns (address signature_address)
+    {
+        // Length of the actual message: 20 + 32 + 32 + 32 + 32 + 32 + 32
+        string memory message_length = '212';
+
+        bytes32 message_hash = keccak256(abi.encodePacked(
+            signature_prefix,
+            message_length,
+            address(this),
+            chain_id,
+            uint256(MessageTypeId.BalanceProof),
+            channel_identifier,
+            balance_hash,
+            nonce,
+            additional_hash
+        ));
+
+        signature_address = ECVerify.ecverify(message_hash, signature);
+    }
+
+    function recoverAddressFromBalanceProofUpdateMessage(
+        uint256 channel_identifier,
+        bytes32 balance_hash,
+        uint256 nonce,
+        bytes32 additional_hash,
+        bytes memory closing_signature,
+        bytes memory non_closing_signature
+    )
+        view
+        internal
+        returns (address signature_address)
+    {
+        // Length of the actual message: 20 + 32 + 32 + 32 + 32 + 32 + 32 + 65
+        string memory message_length = '277';
+
+        bytes32 message_hash = keccak256(abi.encodePacked(
+            signature_prefix,
+            message_length,
+            address(this),
+            chain_id,
+            uint256(MessageTypeId.BalanceProofUpdate),
+            channel_identifier,
+            balance_hash,
+            nonce,
+            additional_hash,
+            closing_signature
+        ));
+
+        signature_address = ECVerify.ecverify(message_hash, non_closing_signature);
+    }
+
+    /* function recoverAddressFromCooperativeSettleSignature(
+        uint256 channel_identifier,
+        address participant1,
+        uint256 participant1_balance,
+        address participant2,
+        uint256 participant2_balance,
+        bytes signature
+    )
+        view
+        internal
+        returns (address signature_address)
+    {
+        // Length of the actual message: 20 + 32 + 32 + 32 + 20 + 32 + 20 + 32
+        string memory message_length = '220';
+
+        bytes32 message_hash = keccak256(abi.encodePacked(
+            signature_prefix,
+            message_length,
+            address(this),
+            chain_id,
+            uint256(MessageTypeId.CooperativeSettle),
+            channel_identifier,
+            participant1,
+            participant1_balance,
+            participant2,
+            participant2_balance
+        ));
+
+        signature_address = ECVerify.ecverify(message_hash, signature);
+    } */
+
+    /* function recoverAddressFromWithdrawMessage(
+        uint256 channel_identifier,
+        address participant,
+        uint256 total_withdraw,
+        bytes signature
+    )
+        view
+        internal
+        returns (address signature_address)
+    {
+        // Length of the actual message: 20 + 32 + 32 + 32 + 20 + 32
+        string memory message_length = '168';
+
+        bytes32 message_hash = keccak256(abi.encodePacked(
+            signature_prefix,
+            message_length,
+            address(this),
+            chain_id,
+            uint256(MessageTypeId.Withdraw),
+            channel_identifier,
+            participant,
+            total_withdraw
+        ));
+
+        signature_address = ECVerify.ecverify(message_hash, signature);
+    } */
+
+    /// @dev Calculates the merkle root for the pending transfers data and
+    /// calculates the amount of tokens that can be unlocked because the secret
+    /// was registered on-chain.
+    function getMerkleRootAndUnlockedAmount(bytes memory merkle_tree_leaves)
+        view
+        internal
+        returns (bytes32, uint256)
+    {
+        uint256 length = merkle_tree_leaves.length;
+
+        // each merkle_tree lock component has this form:
+        // (locked_amount || expiration_block || secrethash) = 3 * 32 bytes
+        require(length % 96 == 0);
+
+        uint256 i;
+        uint256 total_unlocked_amount;
+        uint256 unlocked_amount;
+        bytes32 lockhash;
+        bytes32 merkle_root;
+
+        bytes32[] memory merkle_layer = new bytes32[](length / 96 + 1);
+
+        for (i = 32; i < length; i += 96) {
+            (lockhash, unlocked_amount) = getLockDataFromMerkleTree(merkle_tree_leaves, i);
+            total_unlocked_amount += unlocked_amount;
+            merkle_layer[i / 96] = lockhash;
+        }
+
+        length /= 96;
+
+        while (length > 1) {
+            if (length % 2 != 0) {
+                merkle_layer[length] = merkle_layer[length - 1];
+                length += 1;
+            }
+
+            for (i = 0; i < length - 1; i += 2) {
+                if (merkle_layer[i] == merkle_layer[i + 1]) {
+                    lockhash = merkle_layer[i];
+                } else if (merkle_layer[i] < merkle_layer[i + 1]) {
+                    lockhash = keccak256(abi.encodePacked(merkle_layer[i], merkle_layer[i + 1]));
+                } else {
+                    lockhash = keccak256(abi.encodePacked(merkle_layer[i + 1], merkle_layer[i]));
+                }
+                merkle_layer[i / 2] = lockhash;
+            }
+            length = i / 2;
+        }
+
+        merkle_root = merkle_layer[0];
+
+        return (merkle_root, total_unlocked_amount);
+    }
+
+    function getLockDataFromMerkleTree(bytes memory merkle_tree_leaves, uint256 offset)
+        view
+        internal
+        returns (bytes32, uint256)
+    {
+        uint256 expiration_block;
+        uint256 locked_amount;
+        uint256 reveal_block;
+        bytes32 secrethash;
+        bytes32 lockhash;
+
+        if (merkle_tree_leaves.length <= offset) {
+            return (lockhash, 0);
+        }
+
+        assembly {
+            expiration_block := mload(add(merkle_tree_leaves, offset))
+            locked_amount := mload(add(merkle_tree_leaves, add(offset, 32)))
+            secrethash := mload(add(merkle_tree_leaves, add(offset, 64)))
+        }
+
+        // Calculate the lockhash for computing the merkle root
+        lockhash = keccak256(abi.encodePacked(expiration_block, locked_amount, secrethash));
+
+        // Check if the lock's secret was revealed in the SecretRegistry The
+        // secret must have been revealed in the SecretRegistry contract before
+        // the lock's expiration_block in order for the hash time lock transfer
+        // to be successful.
+        reveal_block = secret_registry.getSecretRevealBlockHeight(secrethash);
+        if (reveal_block == 0 || expiration_block <= reveal_block) {
+            locked_amount = 0;
+        }
+
+        return (lockhash, locked_amount);
+    }
+
+    function min(uint256 a, uint256 b) pure internal returns (uint256)
+    {
+        return a > b ? b : a;
+    }
+
+    function max(uint256 a, uint256 b) pure internal returns (uint256)
+    {
+        return a > b ? a : b;
+    }
+
+    /// @dev Special subtraction function that does not fail when underflowing.
+    /// @param a Minuend
+    /// @param b Subtrahend
+    /// @return Minimum between the result of the subtraction and 0, the maximum
+    /// subtrahend for which no underflow occurs.
+    function failsafe_subtract(uint256 a, uint256 b)
+        pure
+        internal
+        returns (uint256, uint256)
+    {
+        return a > b ? (a - b, b) : (0, a);
+    }
+
+    /// @dev Special addition function that does not fail when overflowing.
+    /// @param a Addend
+    /// @param b Addend
+    /// @return Maximum between the result of the addition or the maximum
+    /// uint256 value.
+    function failsafe_addition(uint256 a, uint256 b)
+        pure
+        internal
+        returns (uint256)
+    {
+        uint256 sum = a + b;
+        return sum >= a ? sum : MAX_SAFE_UINT256;
+    }
+}

--- a/contracts/TokenNetworkRegistry.sol
+++ b/contracts/TokenNetworkRegistry.sol
@@ -1,0 +1,88 @@
+pragma solidity ^0.5.2;
+
+import "raiden/Utils.sol";
+import "raiden/Token.sol";
+import "raiden/TokenNetwork.sol";
+
+
+/// @title TokenNetworkRegistry
+/// @notice The TokenNetwork Registry deploys new TokenNetwork contracts for the
+/// Raiden Network protocol.
+contract TokenNetworkRegistry is Utils {
+
+    string constant public contract_version = "0.5.0";
+    address public secret_registry_address;
+    uint256 public chain_id;
+    uint256 public settlement_timeout_min;
+    uint256 public settlement_timeout_max;
+
+    // Only for the limited Red Eyes release
+    address public deprecation_executor;
+    bool public token_network_created = false;
+
+    // Token address => TokenNetwork address
+    mapping(address => address) public token_to_token_networks;
+
+    event TokenNetworkCreated(address indexed token_address, address indexed token_network_address);
+
+    modifier canCreateTokenNetwork() {
+        require(token_network_created == false);
+        _;
+    }
+
+    constructor(
+        address _secret_registry_address,
+        uint256 _chain_id,
+        uint256 _settlement_timeout_min,
+        uint256 _settlement_timeout_max
+    )
+        public
+    {
+        require(_chain_id > 0);
+        require(_settlement_timeout_min > 0);
+        require(_settlement_timeout_max > 0);
+        require(_settlement_timeout_max > _settlement_timeout_min);
+        require(_secret_registry_address != address(0x0));
+        require(contractExists(_secret_registry_address));
+        secret_registry_address = _secret_registry_address;
+        chain_id = _chain_id;
+        settlement_timeout_min = _settlement_timeout_min;
+        settlement_timeout_max = _settlement_timeout_max;
+
+        deprecation_executor = msg.sender;
+    }
+
+    /// @notice Deploy a new TokenNetwork contract for the Token deployed at
+    /// `_token_address`.
+    /// @param _token_address Ethereum address of an already deployed token, to
+    /// be used in the new TokenNetwork contract.
+    function createERC20TokenNetwork(address _token_address)
+        canCreateTokenNetwork
+        external
+        returns (address token_network_address)
+    {
+        require(token_to_token_networks[_token_address] == address(0x0));
+
+        // We limit the number of token networks to 1 for the Bug Bounty release
+        token_network_created = true;
+
+        TokenNetwork token_network;
+
+        // Token contract checks are in the corresponding TokenNetwork contract
+        token_network = new TokenNetwork(
+            _token_address,
+            secret_registry_address,
+            chain_id,
+            settlement_timeout_min,
+            settlement_timeout_max,
+            deprecation_executor
+        );
+
+        token_network_address = address(token_network);
+
+        token_to_token_networks[_token_address] = token_network_address;
+        emit TokenNetworkCreated(_token_address, token_network_address);
+
+        return token_network_address;
+    }
+}

--- a/contracts/Utils.sol
+++ b/contracts/Utils.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.5.2;
+
+/// @title Utils
+/// @notice Utils contract for various helpers used by the Raiden Network smart
+/// contracts.
+contract Utils {
+    string constant public contract_version = "0.5.0";
+
+    /// @notice Check if a contract exists
+    /// @param contract_address The address to check whether a contract is
+    /// deployed or not
+    /// @return True if a contract exists, false otherwise
+    function contractExists(address contract_address) public view returns (bool) {
+        uint size;
+
+        assembly {
+            size := extcodesize(contract_address)
+        }
+
+        return size > 0;
+    }
+}

--- a/contracts/lib/ECVerify.sol
+++ b/contracts/lib/ECVerify.sol
@@ -1,0 +1,41 @@
+pragma solidity ^0.5.2;
+
+library ECVerify {
+
+    function ecverify(bytes32 hash, bytes memory signature)
+        internal
+        pure
+        returns (address signature_address)
+    {
+        require(signature.length == 65);
+
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+
+        // The signature format is a compact form of:
+        //   {bytes32 r}{bytes32 s}{uint8 v}
+        // Compact means, uint8 is not padded to 32 bytes.
+        assembly {
+            r := mload(add(signature, 32))
+            s := mload(add(signature, 64))
+
+            // Here we are loading the last 32 bytes, including 31 bytes following the signature.
+            v := byte(0, mload(add(signature, 96)))
+        }
+
+        // Version of signature should be 27 or 28, but 0 and 1 are also possible
+        if (v < 27) {
+            v += 27;
+        }
+
+        require(v == 27 || v == 28);
+
+        signature_address = ecrecover(hash, v, r, s);
+
+        // ecrecover returns zero on error
+        require(signature_address != address(0x0));
+
+        return signature_address;
+    }
+}

--- a/contracts/services/MonitoringService.sol
+++ b/contracts/services/MonitoringService.sol
@@ -1,0 +1,285 @@
+pragma solidity ^0.5.2;
+
+import "raiden/Token.sol";
+import "raiden/Utils.sol";
+import "raiden/lib/ECVerify.sol";
+import "raiden/TokenNetwork.sol";
+import "services/RaidenServiceBundle.sol";
+import "services/UserDeposit.sol";
+
+contract MonitoringService is Utils {
+    string constant public contract_version = "0.5.0";
+
+    // Token to be used for paying the rewards
+    Token public token;
+
+    // Raiden Service Bundle contract to use for checking if MS has deposits
+    RaidenServiceBundle public rsb;
+    UserDeposit public user_deposit;
+
+    // keccak256(channel_identifier, token_network_address) => Struct
+    // Keep track of the rewards per channel
+    mapping(bytes32 => Reward) rewards;
+
+    /*
+     *  Structs
+     */
+    struct Reward{
+        // The amount of tokens to be rewarded
+        uint256 reward_amount;
+
+        // Nonce of the most recently provided BP
+        uint256 nonce;
+
+        // Address of the Raiden Node that was monitored
+        // This is also the address that has the reward deducted from its deposit
+        address reward_sender_address;
+
+        // Address of the Monitoring Service who is currently eligible to claim the reward
+        address monitoring_service_address;
+    }
+
+    /*
+     *  Events
+     */
+
+    event NewBalanceProofReceived(
+        address token_network_address,
+        uint256 channel_identifier,
+        uint256 reward_amount,
+        uint256 indexed nonce,
+        address indexed ms_address,
+        address indexed raiden_node_address
+    );
+    event RewardClaimed(address indexed ms_address, uint amount, bytes32 indexed reward_identifier);
+
+    /*
+     *  Modifiers
+     */
+
+    modifier canMonitor(address _ms_address) {
+        require(rsb.deposits(_ms_address) > 0);
+        _;
+    }
+
+    /*
+     *  Constructor
+     */
+
+    /// @notice Set the default values for the smart contract
+    /// @param _token_address The address of the token to use for rewards
+    /// @param _rsb_address The address of the RaidenServiceBundle contract
+    constructor(
+        address _token_address,
+        address _rsb_address,
+        address _udc_address
+    )
+        public
+    {
+        require(_token_address != address(0x0));
+        require(_rsb_address != address(0x0));
+        require(_udc_address != address(0x0));
+        require(contractExists(_token_address));
+        require(contractExists(_rsb_address));
+        require(contractExists(_udc_address));
+
+        token = Token(_token_address);
+        rsb = RaidenServiceBundle(_rsb_address);
+        user_deposit = UserDeposit(_udc_address);
+        // Check if the contract is indeed a token contract
+        require(token.totalSupply() > 0);
+        // Check if the contract is indeed an rsb contract
+        // TODO: Check that some function exists in the contract
+    }
+
+    /// @notice Internal function that updates the Reward struct if a newer balance proof
+    /// is provided in the monitor() function
+    /// @param token_network_address Address of the TokenNetwork being monitored
+    /// @param closing_participant The address of the participant who closed the channel
+    /// @param non_closing_participant Address of the other channel participant. This is
+    /// the participant on whose behalf the MS acts.
+    /// @param reward_amount The amount of tokens to be rewarded
+    /// @param nonce The nonce of the newly provided balance_proof
+    /// @param monitoring_service_address The address of the MS calling monitor()
+    /// @param reward_proof_signature The signature of the signed reward proof
+    function updateReward(
+        address token_network_address,
+        address closing_participant,
+        address non_closing_participant,
+        uint256 reward_amount,
+        uint256 nonce,
+        address monitoring_service_address,
+        bytes memory reward_proof_signature
+    )
+    internal
+    {
+        TokenNetwork token_network = TokenNetwork(token_network_address);
+        uint256 channel_identifier = token_network.getChannelIdentifier(closing_participant, non_closing_participant);
+
+        // Make sure that the reward proof is signed by the non_closing_participant
+        address raiden_node_address = recoverAddressFromRewardProof(
+            channel_identifier,
+            reward_amount,
+            token_network_address,
+            token_network.chain_id(),
+            nonce,
+            reward_proof_signature
+        );
+        require(raiden_node_address == non_closing_participant);
+
+        bytes32 reward_identifier = keccak256(abi.encodePacked(
+            channel_identifier,
+            token_network_address
+        ));
+
+        // Get the Reward struct for the correct channel
+        Reward storage reward = rewards[reward_identifier];
+
+        // Only allow BPs with higher nonce to be submitted
+        require(reward.nonce < nonce);
+
+        // MSC stores channel_identifier, MS_address, reward_amount, nonce
+        // of the MS that provided the balance_proof with highest nonce
+        rewards[reward_identifier] = Reward({
+            reward_amount: reward_amount,
+            nonce: nonce,
+            reward_sender_address: non_closing_participant,
+            monitoring_service_address: monitoring_service_address
+        });
+    }
+
+    /// @notice Called by a registered MS, when providing a new balance proof
+    /// to a monitored channel.
+    /// Can be called multiple times by different registered MSs as long as the BP provided
+    /// is newer than the current newest registered BP.
+    /// @param nonce Strictly monotonic value used to order BPs
+    /// omitting PB specific params, since these will not be provided in the future
+    /// @param reward_amount Amount of tokens to be rewarded
+    /// @param token_network_address Address of the Token Network in which the channel
+    /// being monitored exists.
+    /// @param reward_proof_signature The signature of the signed reward proof
+    function monitor(
+        address closing_participant,
+        address non_closing_participant,
+        bytes32 balance_hash,
+        uint256 nonce,
+        bytes32 additional_hash,
+        bytes memory closing_signature,
+        bytes memory non_closing_signature,
+        uint256 reward_amount,
+        address token_network_address,
+        bytes memory reward_proof_signature
+    )
+        canMonitor(msg.sender)
+        public
+    {
+        updateReward(
+            token_network_address,
+            closing_participant,
+            non_closing_participant,
+            reward_amount,
+            nonce,
+            msg.sender,
+            reward_proof_signature
+        );
+        TokenNetwork token_network = TokenNetwork(token_network_address);
+        uint256 channel_identifier = token_network.getChannelIdentifier(closing_participant, non_closing_participant);
+
+        // Call updateTransfer in the corresponding TokenNetwork
+        token_network.updateNonClosingBalanceProof(
+            channel_identifier,
+            closing_participant,
+            non_closing_participant,
+            balance_hash,
+            nonce,
+            additional_hash,
+            closing_signature,
+            non_closing_signature
+        );
+
+        emit NewBalanceProofReceived(
+            token_network_address,
+            channel_identifier,
+            reward_amount,
+            nonce,
+            msg.sender,
+            non_closing_participant
+        );
+    }
+
+    /// @notice Called after a monitored channel is settled in order for MS to claim the reward
+    /// Can be called once per settled channel by everyone on behalf of MS
+    /// @param token_network_address Address of the Token Network in which the channel
+    /// @param closing_participant Address of the participant of the channel that called close
+    /// @param non_closing_participant The other participant of the channel
+    function claimReward(
+        uint256 channel_identifier,
+        address token_network_address,
+        address closing_participant,
+        address non_closing_participant
+    )
+        public
+        returns (bool)
+    {
+        TokenNetwork token_network = TokenNetwork(token_network_address);
+        bytes32 reward_identifier = keccak256(abi.encodePacked(
+            channel_identifier,
+            token_network_address
+        ));
+
+        // Only allowed to claim, if channel is settled
+        // Channel is settled if it's data has been deleted
+        TokenNetwork.ChannelState channel_state;
+        (, channel_state) = token_network.getChannelInfo(
+            channel_identifier,
+            closing_participant,
+            non_closing_participant
+        );
+        require(channel_state == TokenNetwork.ChannelState.Removed);
+
+        Reward storage reward = rewards[reward_identifier];
+
+        // Make sure that the Reward exists
+        require(reward.reward_sender_address != address(0x0));
+
+        // Add reward to the monitoring services' balance
+        require(user_deposit.transfer(
+            reward.reward_sender_address,
+            reward.monitoring_service_address,
+            reward.reward_amount
+        ));
+
+        emit RewardClaimed(
+            reward.monitoring_service_address,
+            reward.reward_amount,
+            reward_identifier
+        );
+
+        // delete storage
+        delete rewards[reward_identifier];
+    }
+
+    function recoverAddressFromRewardProof(
+        uint256 channel_identifier,
+        uint256 reward_amount,
+        address token_network_address,
+        uint256 chain_id,
+        uint256 nonce,
+        bytes memory signature
+    )
+        pure
+        internal
+        returns (address signature_address)
+    {
+        bytes32 message_hash = keccak256(abi.encodePacked(
+            "\x19Ethereum Signed Message:\n148",
+            channel_identifier,
+            reward_amount,
+            token_network_address,
+            chain_id,
+            nonce
+        ));
+
+        signature_address = ECVerify.ecverify(message_hash, signature);
+    }
+}

--- a/contracts/services/RaidenServiceBundle.sol
+++ b/contracts/services/RaidenServiceBundle.sol
@@ -1,0 +1,30 @@
+pragma solidity ^0.5.2;
+
+import "raiden/Token.sol";
+import "raiden/Utils.sol";
+
+contract RaidenServiceBundle is Utils {
+    string constant public contract_version = "0.5.0";
+    Token public token;
+
+    mapping(address => uint256) public deposits;
+
+    constructor(address _token_address) public {
+        require(_token_address != address(0x0));
+        require(contractExists(_token_address));
+
+        token = Token(_token_address);
+        // Check if the contract is indeed a token contract
+        require(token.totalSupply() > 0);
+    }
+
+    function deposit(uint amount) public {
+        require(amount > 0);
+
+        // This also allows for MSs to deposit and use other MSs
+        deposits[msg.sender] += amount;
+
+        // Transfer the deposit to the smart contract
+        require(token.transferFrom(msg.sender, address(this), amount));
+    }
+}

--- a/contracts/services/UserDeposit.sol
+++ b/contracts/services/UserDeposit.sol
@@ -1,0 +1,179 @@
+pragma solidity ^0.5.2;
+
+import "raiden/Token.sol";
+import "raiden/Utils.sol";
+
+contract UserDeposit is Utils {
+    string constant public contract_version = "0.5.0";
+    uint constant public withdraw_delay = 100;  // time before withdraw is allowed in blocks
+
+    // Token to be used for the deposit
+    Token public token;
+
+    // Trusted contract (can execute `transfer`)
+    address public msc_address;
+
+    // Total amount of tokens that have been deposited. This is monotonous and
+    // doing a transfer or withdrawing tokens will not decrease total_deposit!
+    mapping(address => uint256) public total_deposit;
+    // Current user's balance, ignoring planned withdraws
+    mapping(address => uint256) public balances;
+    mapping(address => WithdrawPlan) public withdraw_plans;
+
+    /*
+     *  Structs
+     */
+    struct WithdrawPlan {
+        uint256 amount;
+        uint256 withdraw_block;  // earliest block at which withdraw is allowed
+    }
+
+    /*
+     *  Events
+     */
+
+    event BalanceReduced(address indexed owner, uint newBalance);
+    event WithdrawPlanned(address indexed withdrawer, uint plannedBalance);
+
+    /*
+     *  Modifiers
+     */
+
+    modifier canTransfer() {
+        require(msg.sender == msc_address);
+        _;
+    }
+
+    /*
+     *  Constructor
+     */
+
+    /// @notice Set the default values for the smart contract
+    /// @param _token_address The address of the token to use for rewards
+    constructor(address _token_address)
+        public
+    {
+        // check token contract
+        require(_token_address != address(0x0));
+        require(contractExists(_token_address));
+        token = Token(_token_address);
+        require(token.totalSupply() > 0); // Check if the contract is indeed a token contract
+    }
+
+    /// @notice Specify trusted contracts. This has to be done outside of the
+    /// constructor to avoid cyclic dependencies.
+    /// @param _msc_address Address of the MonitoringService contract
+    function init(address _msc_address)
+        external
+    {
+        // prevent changes of trusted contract after initialization
+        require(msc_address == address(0x0));
+
+        // check monitoring service contract
+        require(_msc_address != address(0x0));
+        require(contractExists(_msc_address));
+        msc_address = _msc_address;
+    }
+
+    /// @notice Deposit tokens. The amount of transferred tokens will be
+    /// `new_total_deposit - total_deposit[beneficiary]`. This makes the
+    /// function behavior predictable and idempotent. Can be called several
+    /// times and on behalf of other accounts.
+    /// @param beneficiary The account benefiting from the deposit
+    /// @param new_total_deposit The total sum of tokens that have been
+    /// deposited by the user by calling this function.
+    function deposit(address beneficiary, uint256 new_total_deposit)
+        external
+    {
+        require(new_total_deposit > total_deposit[beneficiary]);
+
+        // Calculate the actual amount of tokens that will be transferred
+        uint256 added_deposit = new_total_deposit - total_deposit[beneficiary];
+
+        balances[beneficiary] += added_deposit;
+        total_deposit[beneficiary] += added_deposit;
+        require(token.transferFrom(msg.sender, address(this), added_deposit));
+    }
+
+    /// @notice Internally transfer deposits between two addresses.
+    /// Sender and receiver must be different or the transaction will fail.
+    /// @param sender Account from which the amount will be deducted
+    /// @param receiver Account to which the amount will be credited
+    /// @param amount Amount of tokens to be transferred
+    /// @return true if transfer has been done successfully, otherwise false
+    function transfer(
+        address sender,
+        address receiver,
+        uint256 amount
+    )
+        canTransfer()
+        external
+        returns (bool success)
+    {
+        require(sender != receiver);
+        if (balances[sender] >= amount && amount > 0) {
+            balances[sender] -= amount;
+            balances[receiver] += amount;
+            emit BalanceReduced(sender, balances[sender]);
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /// @notice Announce intention to withdraw tokens.
+    /// Sets the planned withdraw amount and resets the withdraw_block.
+    /// There is only one planned withdrawal at a time, the old one gets overwritten.
+    /// @param amount Maximum amount of tokens to be withdrawn
+    function planWithdraw(uint256 amount)
+        external
+    {
+        require(amount > 0);
+        require(balances[msg.sender] >= amount);
+
+        withdraw_plans[msg.sender] = WithdrawPlan({
+            amount: amount,
+            withdraw_block: block.number + withdraw_delay
+        });
+        emit WithdrawPlanned(msg.sender, balances[msg.sender] - amount);
+    }
+
+    /// @notice Execute a planned withdrawal
+    /// Will only work after the withdraw_delay has expired.
+    /// An amount lower or equal to the planned amount may be withdrawn.
+    /// Removes the withdraw plan even if not the full amount has been
+    /// withdrawn.
+    /// @param amount Amount of tokens to be withdrawn
+    function withdraw(uint256 amount)
+        external
+    {
+        WithdrawPlan storage withdraw_plan = withdraw_plans[msg.sender];
+        require(amount <= withdraw_plan.amount);
+        require(withdraw_plan.withdraw_block <= block.number);
+        uint256 withdrawable = min(amount, balances[msg.sender]);
+        balances[msg.sender] -= withdrawable;
+        require(token.transfer(msg.sender, withdrawable));
+
+        emit BalanceReduced(msg.sender, balances[msg.sender]);
+        delete withdraw_plans[msg.sender];
+    }
+
+    /// @notice The owner's balance with planned withdrawals deducted
+    /// @param owner Address for which the balance should be returned
+    /// @return The remaining balance after planned withdrawals
+    function effectiveBalance(address owner)
+        external
+        returns (uint256 remaining_balance)
+    {
+        WithdrawPlan storage withdraw_plan = withdraw_plans[owner];
+        if (withdraw_plan.amount > balances[owner]) {
+            return 0;
+        }
+        return balances[owner] - withdraw_plan.amount;
+    }
+
+    function min(uint256 a, uint256 b) pure internal returns (uint256)
+    {
+        return a > b ? b : a;
+    }
+}

--- a/contracts/test/CustomToken.sol
+++ b/contracts/test/CustomToken.sol
@@ -1,0 +1,96 @@
+pragma solidity ^0.5.2;
+
+/*
+This Token Contract implements the standard token functionality (https://github.com/ethereum/EIPs/issues/20), the ERC223 functionality (https://github.com/ethereum/EIPs/issues/223) as well as the following OPTIONAL extras intended for use by humans.
+
+In other words. This is intended for deployment in something like a Token Factory or Mist wallet, and then used by humans.
+Imagine coins, currencies, shares, voting weight, etc.
+Machine-based, rapid creation of many tokens would not necessarily need these extra features or will be minted in other manners.
+
+1) Initial Finite Supply (upon creation one specifies how much is minted).
+2) In the absence of a token registry: Optional Decimal, Symbol & Name.
+
+.*/
+
+import "test/StandardToken.sol";
+
+/// @title CustomToken
+contract CustomToken is StandardToken {
+
+    /*
+     *  Token metadata
+     */
+    string public version = 'H0.1';       //human 0.1 standard. Just an arbitrary versioning scheme.
+    string public name;
+    string public symbol;
+    uint8 public _decimals;
+    uint256 public multiplier;
+
+    address payable public owner_address;
+
+    /*
+     * Events
+     */
+    event Minted(address indexed _to, uint256 indexed _num);
+
+    /*
+     *  Public functions
+     */
+    /// @dev Contract constructor function.
+    /// @param initial_supply Initial supply of tokens.
+    /// @param decimal_units Number of token decimals.
+    /// @param token_name Token name for display.
+    /// @param token_symbol Token symbol.
+    constructor(
+        uint256 initial_supply,
+        uint8 decimal_units,
+        string memory token_name,
+        string memory token_symbol
+    )
+        public
+    {
+        // Set the name for display purposes
+        name = token_name;
+
+        // Amount of decimals for display purposes
+        _decimals = decimal_units;
+        multiplier = 10**(uint256(decimal_units));
+
+        // Set the symbol for display purposes
+        symbol = token_symbol;
+
+        // Initial supply is assigned to the owner
+        owner_address = msg.sender;
+        balances[owner_address] = initial_supply;
+        _total_supply = initial_supply;
+    }
+
+    /// @notice Allows `num` tokens to be minted and assigned to `msg.sender`
+    function mint(uint256 num) public {
+        mintFor(num, msg.sender);
+    }
+
+    /// @notice Allows `num` tokens to be minted and assigned to `target`
+    function mintFor(uint256 num, address target) public {
+        balances[target] += num;
+        _total_supply += num;
+
+        emit Minted(target, num);
+
+        require(balances[target] >= num);
+        assert(_total_supply >= num);
+    }
+
+    /// @notice Transfers the collected ETH to the contract owner.
+    function transferFunds() public {
+        require(msg.sender == owner_address);
+        require(address(this).balance > 0);
+
+        owner_address.transfer(address(this).balance);
+        assert(address(this).balance == 0);
+    }
+
+    function decimals() public view returns (uint8 decimals) {
+        return _decimals;
+    }
+}

--- a/contracts/test/HumanStandardToken.sol
+++ b/contracts/test/HumanStandardToken.sol
@@ -1,0 +1,73 @@
+pragma solidity ^0.5.2;
+
+import "test/StandardToken.sol";
+
+/*
+This Token Contract implements the standard token functionality (https://github.com/ethereum/EIPs/issues/20) as well as the following OPTIONAL extras intended for use by humans.
+
+In other words. This is intended for deployment in something like a Token Factory or Mist wallet, and then used by humans.
+Imagine coins, currencies, shares, voting weight, etc.
+Machine-based, rapid creation of many tokens would not necessarily need these extra features or will be minted in other manners.
+
+1) Initial Finite Supply (upon creation one specifies how much is minted).
+2) In the absence of a token registry: Optional Decimal, Symbol & Name.
+3) Optional approveAndCall() functionality to notify a contract if an approval() has occurred.
+
+.*/
+
+contract HumanStandardToken is StandardToken {
+    /* Public variables of the token */
+
+    /*
+    NOTE:
+    The following variables are OPTIONAL vanities. One does not have to include them.
+    They allow one to customise the token contract & in no way influences the core functionality.
+    Some wallets/interfaces might not even bother to look at this information.
+    */
+    string public name;                   //fancy name: eg Simon Bucks
+    uint8 public _decimals;                //How many decimals to show. ie. There could 1000 base units with 3 decimals. Meaning 0.980 SBX = 980 base units. It's like comparing 1 wei to 1 ether.
+    string public symbol;                 //An identifier: eg SBX
+    string public version = 'H0.1';       //human 0.1 standard. Just an arbitrary versioning scheme.
+
+    constructor(
+        uint256 _initialAmount,
+        uint8 _decimalUnits,
+        string memory _tokenName,
+        string memory _tokenSymbol
+    )
+        public
+    {
+        balances[msg.sender] = _initialAmount;               // Give the creator all initial tokens
+        _total_supply = _initialAmount;                        // Update total supply
+        name = _tokenName;                                   // Set the name for display purposes
+        _decimals = _decimalUnits;                            // Amount of decimals for display purposes
+        symbol = _tokenSymbol;                               // Set the symbol for display purposes
+    }
+
+    /* Approves and then calls the receiving contract */
+    function approveAndCall(address _spender, uint256 _value, bytes memory _extraData)
+        public
+        returns (bool success)
+    {
+        allowed[msg.sender][_spender] = _value;
+        //call the receiveApproval function on the contract you want to be notified. This crafts the function signature manually so one doesn't have to include a contract in here just for this.
+        //receiveApproval(address _from, uint256 _value, address _tokenContract, bytes _extraData)
+        (bool success, bytes memory data) = _spender.call(abi.encodeWithSignature(
+            "receiveApproval(address,uint256,address,bytes)",
+            msg.sender,
+            _value,
+            this,
+            _extraData
+        ));
+        require(success);
+
+        emit Approval(msg.sender, _spender, _value);
+        return true;
+    }
+
+    function () external { revert(); }
+
+    function decimals() public view returns (uint8 decimals) {
+        return _decimals;
+    }
+}

--- a/contracts/test/SignatureVerifyTest.sol
+++ b/contracts/test/SignatureVerifyTest.sol
@@ -1,0 +1,26 @@
+pragma solidity ^0.5.2;
+
+/*
+ * This is a contract used for testing the ECVerify library and ecrecover behaviour.
+ */
+
+import "raiden/lib/ECVerify.sol";
+
+contract SignatureVerifyTest {
+    function verify(bytes32 _message_hash, bytes memory _signed_message)
+        pure
+        public
+        returns (address signer)
+    {
+        // Derive address from signature
+        signer = ECVerify.ecverify(_message_hash, _signed_message);
+    }
+
+    function verifyEcrecoverOutput(bytes32 hash, bytes32 r, bytes32 s, uint8 v)
+        pure
+        public
+        returns (address signature_address)
+    {
+        signature_address = ecrecover(hash, v, r, s);
+    }
+}

--- a/contracts/test/StandardToken.sol
+++ b/contracts/test/StandardToken.sol
@@ -1,0 +1,67 @@
+pragma solidity ^0.5.2;
+
+import "raiden/Token.sol";
+
+/*
+This implements ONLY the standard functions and NOTHING else.
+For a token like you would want to deploy in something like Mist, see HumanStandardToken.sol.
+
+If you deploy this, you won't have anything useful.
+
+Implements ERC 20 Token standard: https://github.com/ethereum/EIPs/issues/20
+.*/
+
+contract StandardToken is Token {
+    uint256 internal _total_supply;
+    mapping (address => uint256) public balances;
+    mapping (address => mapping (address => uint256)) allowed;
+
+    function transfer(address _to, uint256 _value) public returns (bool success) {
+        //Default assumes totalSupply can't be over max (2^256 - 1).
+        //If your token leaves out totalSupply and can issue more tokens as time goes on, you need to check if it doesn't wrap.
+        //Replace the if with this one instead.
+        //if (balances[msg.sender] >= _value && balances[_to] + _value > balances[_to]) {
+        if (balances[msg.sender] >= _value && _value > 0) {
+            balances[msg.sender] -= _value;
+            balances[_to] += _value;
+            emit Transfer(msg.sender, _to, _value);
+            return true;
+        } else { return false; }
+    }
+
+    function transferFrom(address _from, address _to, uint256 _value)
+        public
+        returns (bool success)
+    {
+        //same as above. Replace this line with the following if you want to protect against wrapping uints.
+        //if (balances[_from] >= _value && allowed[_from][msg.sender] >= _value && balances[_to] + _value > balances[_to]) {
+        require(balances[_from] >= _value);
+        require(allowed[_from][msg.sender] >= _value);
+        require(_value > 0);
+        if ((balances[_from] >= _value) && (allowed[_from][msg.sender] >= _value) && (_value > 0)) {
+            balances[_to] += _value;
+            balances[_from] -= _value;
+            allowed[_from][msg.sender] -= _value;
+            emit Transfer(_from, _to, _value);
+            return true;
+        } else { return false; }
+    }
+
+    function balanceOf(address _owner) public view returns (uint256 balance) {
+        return balances[_owner];
+    }
+
+    function approve(address _spender, uint256 _value) public returns (bool success) {
+        allowed[msg.sender][_spender] = _value;
+        emit Approval(msg.sender, _spender, _value);
+        return true;
+    }
+
+    function allowance(address _owner, address _spender) public view returns (uint256 remaining) {
+      return allowed[_owner][_spender];
+    }
+
+    function totalSupply() public view returns (uint256 supply) {
+        return _total_supply;
+    }
+}

--- a/contracts/test/TokenNetworkInternalsTest.sol
+++ b/contracts/test/TokenNetworkInternalsTest.sol
@@ -1,0 +1,305 @@
+pragma solidity ^0.5.2;
+
+import "raiden/TokenNetwork.sol";
+
+contract TokenNetworkInternalStorageTest is TokenNetwork {
+    constructor (
+        address _token_address,
+        address _secret_registry,
+        uint256 _chain_id,
+        uint256 _settlement_timeout_min,
+        uint256 _settlement_timeout_max
+    )
+        TokenNetwork(
+            _token_address,
+            _secret_registry,
+            _chain_id,
+            _settlement_timeout_min,
+            _settlement_timeout_max,
+            msg.sender
+        )
+        public
+    {
+
+    }
+
+    function updateBalanceProofDataPublic(
+        uint256 channel_identifier,
+        address participant,
+        uint256 nonce,
+        bytes32 balance_hash
+    )
+        public
+    {
+        Channel storage channel = channels[channel_identifier];
+        return updateBalanceProofData(
+            channel,
+            participant,
+            nonce,
+            balance_hash
+        );
+    }
+
+    function updateUnlockDataPublic(
+        uint256 channel_identifier,
+        address participant,
+        address partner,
+        uint256 locked_amount,
+        bytes32 locksroot
+    )
+        public
+    {
+       return storeUnlockData(
+            channel_identifier,
+            participant,
+            partner,
+            locked_amount,
+            locksroot
+        );
+    }
+
+    function getMaxPossibleReceivableAmountPublic(
+        address participant1,
+        uint256 participant1_transferred_amount,
+        uint256 participant1_locked_amount,
+        address participant2,
+        uint256 participant2_transferred_amount,
+        uint256 participant2_locked_amount
+    )
+        view
+        public
+        returns (uint256)
+    {
+
+        uint256 channel_identifier;
+
+        channel_identifier = getChannelIdentifier(participant1, participant2);
+        Channel storage channel = channels[channel_identifier];
+        Participant storage participant1_state = channel.participants[participant1];
+        Participant storage participant2_state = channel.participants[participant2];
+        SettlementData memory participant1_settlement;
+        SettlementData memory participant2_settlement;
+
+        participant1_settlement.deposit = participant1_state.deposit;
+        participant1_settlement.withdrawn = participant1_state.withdrawn_amount;
+        participant1_settlement.transferred = participant1_transferred_amount;
+        participant1_settlement.locked = participant1_locked_amount;
+
+        participant2_settlement.deposit = participant2_state.deposit;
+        participant2_settlement.withdrawn = participant2_state.withdrawn_amount;
+        participant2_settlement.transferred = participant2_transferred_amount;
+        participant2_settlement.locked = participant2_locked_amount;
+        return getMaxPossibleReceivableAmount(
+            participant1_settlement,
+            participant2_settlement
+        );
+    }
+
+    function verifyBalanceHashDataPublic(
+        address to_verify,
+        address partner,
+        uint256 transferred_amount,
+        uint256 locked_amount,
+        bytes32 locksroot
+    )
+        view
+        public
+        returns (bool)
+    {
+        uint256 channel_identifier;
+        channel_identifier = getChannelIdentifier(to_verify, partner);
+        Channel storage channel = channels[channel_identifier];
+        Participant storage to_verify_state = channel.participants[to_verify];
+        return verifyBalanceHashData(
+            to_verify_state,
+            transferred_amount,
+            locked_amount,
+            locksroot
+        );
+    }
+
+    function getChannelAvailableDepositPublic(
+        address participant1,
+        address participant2
+    )
+        view
+        public
+        returns (uint256 total_available_deposit)
+    {
+        uint256 channel_identifier = getChannelIdentifier(participant1,
+        participant2);
+        Channel storage channel = channels[channel_identifier];
+        Participant storage participant1_state = channel.participants[participant1];
+        Participant storage participant2_state = channel.participants[participant2];
+        return getChannelAvailableDeposit(
+           participant1_state,
+           participant2_state
+        );
+    }
+}
+
+contract TokenNetworkSignatureTest is TokenNetwork {
+    constructor (
+        address _token_address,
+        address _secret_registry,
+        uint256 _chain_id,
+        uint256 _settlement_timeout_min,
+        uint256 _settlement_timeout_max
+    )
+        TokenNetwork(
+            _token_address,
+            _secret_registry,
+            _chain_id,
+            _settlement_timeout_min,
+            _settlement_timeout_max,
+            msg.sender
+        )
+        public
+    {
+
+    }
+
+    function recoverAddressFromBalanceProofPublic(
+        uint256 channel_identifier,
+        bytes32 balance_hash,
+        uint256 nonce,
+        bytes32 additional_hash,
+        bytes memory signature
+    )
+        view
+        public
+        returns (address signature_address)
+    {
+        return recoverAddressFromBalanceProof(
+            channel_identifier,
+            balance_hash,
+            nonce,
+            additional_hash,
+            signature
+        );
+    }
+
+    function recoverAddressFromBalanceProofUpdateMessagePublic(
+        uint256 channel_identifier,
+        bytes32 balance_hash,
+        uint256 nonce,
+        bytes32 additional_hash,
+        bytes memory closing_signature,
+        bytes memory non_closing_signature
+    )
+        view
+        public
+        returns (address signature_address)
+    {
+        return recoverAddressFromBalanceProofUpdateMessage(
+            channel_identifier,
+            balance_hash,
+            nonce,
+            additional_hash,
+            closing_signature,
+            non_closing_signature
+        );
+    }
+
+    /* function recoverAddressFromCooperativeSettleSignaturePublic(
+        uint256 channel_identifier,
+        address participant1,
+        uint256 participant1_balance,
+        address participant2,
+        uint256 participant2_balance,
+        bytes signature
+    )
+        view
+        public
+        returns (address signature_address)
+    {
+        return recoverAddressFromCooperativeSettleSignature(
+            channel_identifier,
+            participant1,
+            participant1_balance,
+            participant2,
+            participant2_balance,
+            signature
+        );
+    } */
+
+    /* function recoverAddressFromWithdrawMessagePublic(
+        uint256 channel_identifier,
+        address participant,
+        uint256 amount_to_withdraw,
+        bytes signature
+    )
+        view
+        public
+        returns (address signature_address)
+    {
+        return recoverAddressFromWithdrawMessage(
+            channel_identifier,
+            participant,
+            amount_to_withdraw,
+            signature
+        );
+    } */
+}
+
+contract TokenNetworkUtilsTest is TokenNetwork {
+    constructor (
+        address _token_address,
+        address _secret_registry,
+        uint256 _chain_id,
+        uint256 _settlement_timeout_min,
+        uint256 _settlement_timeout_max
+    )
+        TokenNetwork(
+            _token_address,
+            _secret_registry,
+            _chain_id,
+            _settlement_timeout_min,
+            _settlement_timeout_max,
+            msg.sender
+        )
+        public
+    {
+
+    }
+
+    function getMerkleRootAndUnlockedAmountPublic(bytes memory merkle_tree_leaves)
+        view
+        public
+        returns (bytes32, uint256)
+    {
+        return getMerkleRootAndUnlockedAmount(merkle_tree_leaves);
+    }
+
+    function getLockDataFromMerkleTreePublic(bytes memory merkle_tree_leaves, uint256 offset)
+        view
+        public
+        returns (bytes32, uint256)
+    {
+        return getLockDataFromMerkleTree(merkle_tree_leaves, offset);
+    }
+
+    function minPublic(uint256 a, uint256 b) view public returns (uint256)
+    {
+        return min(a,b);
+    }
+
+    function maxPublic(uint256 a, uint256 b) view public returns (uint256)
+    {
+        return max(a,b);
+    }
+
+    function failsafe_subtractPublic(uint256 a, uint256 b) view public returns (uint256, uint256)
+    {
+        return failsafe_subtract(a,b);
+    }
+
+    function failsafe_additionPublic(uint256 a, uint256 b) view public returns (uint256)
+    {
+        return failsafe_addition(a, b);
+    }
+
+    function get_max_safe_uint256() pure public returns (uint256) {
+        return uint256(0 - 1);
+    }
+}

--- a/contracts/test/UDCTransfer.sol
+++ b/contracts/test/UDCTransfer.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.5.2;
+
+import "services/UserDeposit.sol";
+
+// Basic contract to test the UDC's transfer function by passing this contract
+// as a trusted contract to the UDC.
+
+contract UDCTransfer {
+
+    UserDeposit user_deposit_contract;
+
+    constructor(address udc_address)
+        public
+    {
+        require(udc_address != address(0x0));
+        user_deposit_contract = UserDeposit(udc_address);
+    }
+
+    function transfer(address sender, address receiver, uint256 amount)
+        external
+        returns (bool success)
+    {
+        return user_deposit_contract.transfer(sender, receiver, amount);
+    }
+}


### PR DESCRIPTION
It tried to avoid this but all alternatives were worse:
* make targets are not executed by readthedocs
* adding download code to conf.py would be surprising
* adding raiden-contracts to requirements.txt and getting the contracts
path from there worked fine locally, but readthedocs fails on
raiden-contracts' depencencies
* adding a custom readthedocs builder would be an overly complicated
solution to this problem

So unless somebody has a different solution it's this or no autodoc.