### PR TITLE
Reflect Message ID differentiation for closing and updating

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -147,7 +147,7 @@ Fields
 +-----------------------+------------+--------------------------------------------------------------------------------------------+
 | chain_id              | uint256    | Chain identifier as defined in EIP155                                                      |
 +-----------------------+------------+--------------------------------------------------------------------------------------------+
-| message_type_id       | uint256    | ``2`` = message type identifier                                                            |
+| message_type_id       | uint256    | ``1`` (if closing) or ``2`` (if updating)                                                           |
 +-----------------------+------------+--------------------------------------------------------------------------------------------+
 |  channel_identifier   | uint256    | Channel identifier inside the TokenNetwork contract                                        |
 +-----------------------+------------+--------------------------------------------------------------------------------------------+
@@ -162,6 +162,9 @@ Fields
 +-----------------------+------------+--------------------------------------------------------------------------------------------+
 |  signature            | bytes      | Elliptic Curve 256k1 signature on the above data from the non-closing participant          |
 +-----------------------+------------+--------------------------------------------------------------------------------------------+
+
+The same message ID ``1`` is used for Balance Proof Update and Balance Proof messages.  This is not a problem because these messages have different lengths.
+
 
 .. _withdraw-proof:
 

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -163,6 +163,13 @@ Fields
 |  signature            | bytes      | Elliptic Curve 256k1 signature on the above data from the non-closing participant          |
 +-----------------------+------------+--------------------------------------------------------------------------------------------+
 
+Importance of message type IDs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The different values of ``message_type_id`` convey how the second signer intends to use the balance proof.  Funds can be lost if a malicious party gets a Balance Proof Update message with ``message_type_id == 1``. Once the malicious party submits the Balance Proof Update message to TokenNetwork, TokenNetwork considers the submitted balance proof final, even if the message was originally signed a long time ago.
+
+A Balance Proof Update message with ``message_type_id == 2`` can be shared with third parties (like Monitoring Services) or shown publicly. TokenNetwork contract waits during the settlement window for Balance Proof Update messages with ``message_type_id == 2`` and chooses the latest one.
+
 The same message ID ``1`` is used for Balance Proof Update and Balance Proof messages.  This is not a problem because these messages have different lengths.
 
 


### PR DESCRIPTION
This follows the implementation change in
https://github.com/raiden-network/raiden-contracts/pull/1150

Since Balance Proof Update message is used both for closeChnanel()
and updateNonClosingBalanceProof() call, the signature must be
differentiated using different message IDs.