### PR TITLE
Add locksroots in ChannelSettled event

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -611,7 +611,9 @@ Settles the channel by transferring the amount of tokens each participant is owe
     event ChannelSettled(
         uint256 indexed channel_identifier,
         uint256 participant1_amount,
-        uint256 participant2_amount
+        bytes32 participant1_locksroot,
+        uint256 participant2_amount,
+        bytes32 participant2_locksroot
     );
 
 - ``channel_identifier``: :term:`Channel identifier` assigned by the current contract.


### PR DESCRIPTION
This follows the implementation change made in
https://github.com/raiden-network/raiden-contracts/pull/1126

This commit is a part of updating the spec
https://github.com/raiden-network/spec/issues/253