### PR TITLE
Add expiration_block to setTotalWithdraw() args

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -475,7 +475,7 @@ Allows a channel participant to withdraw tokens from a channel without closing i
 - ``total_withdraw``: Total amount of tokens that are marked as withdrawn from the channel during the channel lifecycle.
 - ``participant_signature``: Elliptic Curve 256k1 signature of the channel ``participant`` on the :term:`withdraw proof` data.
 - ``partner_signature``: Elliptic Curve 256k1 signature of the channel ``partner`` on the :term:`withdraw proof` data.
-- ``expiration_block``: the block number when the withdraw message becomes no longer valid.
+- ``expiration_block``: The first block number when the withdraw message is no longer valid.
 
 .. Note::
     A ``participant`` ``MUST NOT`` be able to withdraw tokens from the channel without his ``partner``'s signature.

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -456,6 +456,7 @@ Allows a channel participant to withdraw tokens from a channel without closing i
         uint256 channel_identifier,
         address participant,
         uint256 total_withdraw,
+        uint256 expiration_block,
         bytes participant_signature,
         bytes partner_signature
     )
@@ -474,6 +475,7 @@ Allows a channel participant to withdraw tokens from a channel without closing i
 - ``total_withdraw``: Total amount of tokens that are marked as withdrawn from the channel during the channel lifecycle.
 - ``participant_signature``: Elliptic Curve 256k1 signature of the channel ``participant`` on the :term:`withdraw proof` data.
 - ``partner_signature``: Elliptic Curve 256k1 signature of the channel ``partner`` on the :term:`withdraw proof` data.
+- ``expiration_block``: the block number when the withdraw message becomes no longer valid.
 
 .. Note::
     A ``participant`` ``MUST NOT`` be able to withdraw tokens from the channel without his ``partner``'s signature.


### PR DESCRIPTION
This commit adds the new argument `expiration_block` to
`setTotalWithdraw()` function.

The change follows the implementation
https://github.com/raiden-network/raiden-contracts/pull/1103

This commit is a part of updating the spec
https://github.com/raiden-network/spec/issues/253