### PR TITLE
Hashlocks are on SHA256 now

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -736,7 +736,7 @@ Getters
     function getSecretRevealBlockHeight(bytes32 secrethash) public view returns (uint256)
 
 - ``secret``: The preimage used to derive a secrethash. Currently, ``registerSecret()`` fails if the ``secret`` is zero.
-- ``secrethash``: ``keccak256(secret)``.
+- ``secrethash``: ``sha256(secret)``.
 
 
 EndpointRegistry Contract


### PR DESCRIPTION
The implementation changed the hash function
for the hashtimelocks
https://github.com/raiden-network/raiden-contracts/pull/979

This commit reflects that in the spec.

This commit is a part of updating the spec:
https://github.com/raiden-network/spec/issues/253