### PR TITLE
setTotalWithdraw function is available now

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -448,9 +448,6 @@ Deposit more tokens into a channel. This will only increase the deposit of one o
 
 **Withdraw tokens from a channel**
 
-.. Warning::
-    ``setTotalWithdraw`` function is currently commented out and is not available.
-
 Allows a channel participant to withdraw tokens from a channel without closing it. Can be called by anyone. Can only be called once per each signed withdraw proof.
 
 ::


### PR DESCRIPTION
The implementation re-enabled setTotalWithdraw in
https://github.com/raiden-network/raiden-contracts/pull/711

This commit reflects the change in the spec.

This commit is a part of updating the spec:
https://github.com/raiden-network/spec/issues/253