### PR TITLE
Update messages specification for Alderaan

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -9,6 +9,7 @@ This is a tentative specification for the `Raiden Network <http://raiden.network
    :caption: Contents:
 
    messaging
+   mediated_transfer
    transport
    smart_contracts
    service_contracts

--- a/mediated_transfer.rst
+++ b/mediated_transfer.rst
@@ -4,18 +4,22 @@ Mediated transfers
 Overview
 ========
 
-The protocol supports mediated transfers. Nodes may use them to send payments.
-A :term:`Mediated transfer` may be cancelled and can expire until the initiator reveals the secret.
+Nodes can use a :term:`mediated transfer` to send payments to another node without opening a
+direct channel to it.
 
-A mediated transfer is done in two stages, possibly on a series of channels:
+A mediated transfer is done in two stages, usually through multiple channels:
 
-- Reserve token :term:`capacity` for a given payment, using a :ref:`locked transfer message <locked-transfer-message>`.
-- Use the reserved token amount to complete payments, using the :ref:`unlock message <unlock-message>`
+- **Allocation:** Reserve token :term:`capacity` for a given payment, using a
+  :ref:`locked transfer message <locked-transfer-message>`.
+- **Finalization:** Use the reserved token amount to complete payments, using the
+  :ref:`unlock message <unlock-message>`
+
+A mediated transfer may be cancelled and can expire until the initiator reveals the secret.
 
 Mediated Transfers
 ==================
 
-A :term:`Mediated Transfer` is a hash-time-locked transfer. Currently raiden supports only one type of lock. The lock has an amount that is being transferred, a :term:`secrethash` used to verify the secret that unlocks it, and a :term:`lock expiration` to determine its validity.
+A :term:`mediated transfer` is a hash-time-locked transfer. Currently raiden supports only one type of lock. The lock has an amount that is being transferred, a :term:`secrethash` used to verify the secret that unlocks it, and a :term:`lock expiration` to determine its validity.
 
 Mediated transfers have an :term:`initiator` and a :term:`target` and a number of mediators in between. The number of mediators can also be zero as these transfers can also be sent to a direct partner. Assuming ``N`` number of mediators, a mediated transfer will require ``10N + 16`` messages to complete. These are:
 
@@ -42,17 +46,17 @@ For the simplest Alice - Bob example:
 - Bob sends a ``RevealSecret`` message back to Alice to inform her that the secret is known and acts as a request for off-chain synchronization.
 - Finally Alice sends an ``Unlock`` message to Bob. This acts also as a synchronization message informing Bob that the lock will be removed from the list of pending locks and that the transferred_amount and locksroot values are updated.
 
-Mediated Transfer - Best Case Scenario
---------------------------------------
+Mediated Transfer - Happy Path Scenario
+---------------------------------------
 
-In the best case scenario, all Raiden nodes are online and send the final balance proofs off-chain.
+In the happy path scenario, all Raiden nodes are online and send the final balance proofs off-chain.
 
 .. image:: diagrams/RaidenClient_mediated_transfer_good.png
     :alt: Mediated Transfer Good Behaviour
     :width: 900px
 
-Mediated Transfer - Worst Case Scenario
----------------------------------------
+Mediated Transfer - Unhappy Path Scenario
+-----------------------------------------
 
 In case a Raiden node goes offline or does not send the final balance proof to its payee, then the payee can register the ``secret`` on-chain, in the ``SecretRegistry`` smart contract before the ``secret`` expires. This can be used to ``unlock`` the lock on-chain after the channel is settled.
 

--- a/mediated_transfer.rst
+++ b/mediated_transfer.rst
@@ -30,21 +30,26 @@ Mediated transfers have an :term:`initiator` and a :term:`target` and a number o
 - ``2N + 3`` processed (one for everything above)
 - ``5N + 8`` delivered
 
-For the simplest Alice - Bob example:
+For a simple example with one mediator:
 
-- Alice wants to transfer ``n`` tokens to Bob.
+- Alice wants to transfer ``n`` tokens to Charlie, using Bob as a mediator.
 - Alice creates a new transfer with:
-    * transferred_amount = ``current_value``
-    * lock = ``Lock(n, hash(secret), expiration)``
-    * locked_amount = ``updated value containing the lock amount``
-    * locksroot = ``updated value containing the lock``
-    * nonce = ``current_value + 1``
+
+  - ``transferred_amount`` = previous ``transferred_amount``, unchanged
+  - ``lock`` = ``Lock(n, hash(secret), expiration)``
+  - ``locked_amount`` = previous ``locked_amount`` plus ``n``
+  - ``locksroot`` = updated value containing the new ``lock``
+  - ``nonce`` = previous ``nonce`` plus 1.
+
 - Alice signs the transfer and sends it to Bob.
-- Bob requests the secret that can be used for withdrawing the transfer by sending a ``SecretRequest`` message.
-- Alice sends the ``RevealSecret`` to Bob and at this point she must assume the transfer is complete.
-- Bob receives the secret and at this point has effectively secured the transfer of ``n`` tokens to his side.
-- Bob sends a ``RevealSecret`` message back to Alice to inform her that the secret is known and acts as a request for off-chain synchronization.
-- Finally Alice sends an ``Unlock`` message to Bob. This acts also as a synchronization message informing Bob that the lock will be removed from the list of pending locks and that the transferred_amount and locksroot values are updated.
+- Bob forwards the transfer to Charlie.
+- Charlie requests the secret that can be used for withdrawing the transfer by sending a ``SecretRequest`` message to Alice.
+- Alice sends the ``RevealSecret`` to Charlie and at this point she must assume the transfer is complete.
+- Charlie receives the secret and at this point has effectively secured the transfer of ``n`` tokens to his side.
+- Charlie sends a ``RevealSecret`` message to Bob to inform him that the secret is known and acts as a request for off-chain synchronization.
+- Bob sends an ``Unlock`` message to Charlie. This acts also as a synchronization message informing Charlie that the lock will be removed from the list of pending locks and that the ``transferred_amount`` and ``locksroot`` values are updated.
+- Bob sends a ``RevealSecret`` message to Alice.
+- Finally Alice sends an ``Unlock`` to Bob, completing the transfer.
 
 Mediated Transfer - Happy Path Scenario
 ---------------------------------------

--- a/mediated_transfer.rst
+++ b/mediated_transfer.rst
@@ -1,0 +1,71 @@
+Mediated transfers
+##################
+
+Overview
+========
+
+The protocol supports mediated transfers. Nodes may use them to send payments.
+A :term:`Mediated transfer` may be cancelled and can expire until the initiator reveals the secret.
+
+A mediated transfer is done in two stages, possibly on a series of channels:
+
+- Reserve token :term:`capacity` for a given payment, using a :ref:`locked transfer message <locked-transfer-message>`.
+- Use the reserved token amount to complete payments, using the :ref:`unlock message <unlock-message>`
+
+Mediated Transfers
+==================
+
+A :term:`Mediated Transfer` is a hash-time-locked transfer. Currently raiden supports only one type of lock. The lock has an amount that is being transferred, a :term:`secrethash` used to verify the secret that unlocks it, and a :term:`lock expiration` to determine its validity.
+
+Mediated transfers have an :term:`initiator` and a :term:`target` and a number of mediators in between. The number of mediators can also be zero as these transfers can also be sent to a direct partner. Assuming ``N`` number of mediators, a mediated transfer will require ``10N + 16`` messages to complete. These are:
+
+- ``N + 1`` :term:`locked transfer` or :term:`refund transfer` messages
+- ``1`` :term:`secret request`
+- ``N + 2`` :term:`reveal secret`
+- ``N + 1`` :term:`unlock`
+- ``2N + 3`` processed (one for everything above)
+- ``5N + 8`` delivered
+
+For the simplest Alice - Bob example:
+
+- Alice wants to transfer ``n`` tokens to Bob.
+- Alice creates a new transfer with:
+    * transferred_amount = ``current_value``
+    * lock = ``Lock(n, hash(secret), expiration)``
+    * locked_amount = ``updated value containing the lock amount``
+    * locksroot = ``updated value containing the lock``
+    * nonce = ``current_value + 1``
+- Alice signs the transfer and sends it to Bob.
+- Bob requests the secret that can be used for withdrawing the transfer by sending a ``SecretRequest`` message.
+- Alice sends the ``RevealSecret`` to Bob and at this point she must assume the transfer is complete.
+- Bob receives the secret and at this point has effectively secured the transfer of ``n`` tokens to his side.
+- Bob sends a ``RevealSecret`` message back to Alice to inform her that the secret is known and acts as a request for off-chain synchronization.
+- Finally Alice sends an ``Unlock`` message to Bob. This acts also as a synchronization message informing Bob that the lock will be removed from the list of pending locks and that the transferred_amount and locksroot values are updated.
+
+Mediated Transfer - Best Case Scenario
+--------------------------------------
+
+In the best case scenario, all Raiden nodes are online and send the final balance proofs off-chain.
+
+.. image:: diagrams/RaidenClient_mediated_transfer_good.png
+    :alt: Mediated Transfer Good Behaviour
+    :width: 900px
+
+Mediated Transfer - Worst Case Scenario
+---------------------------------------
+
+In case a Raiden node goes offline or does not send the final balance proof to its payee, then the payee can register the ``secret`` on-chain, in the ``SecretRegistry`` smart contract before the ``secret`` expires. This can be used to ``unlock`` the lock on-chain after the channel is settled.
+
+.. image:: diagrams/RaidenClient_mediated_transfer_secret_reveal.png
+    :alt: Mediated Transfer Bad Behaviour
+    :width: 900px
+
+Restrictions to mediated transfers
+==================================
+
+Limit to number of simultaneously pending transfers
+---------------------------------------------------
+
+The number of simultaneously pending transfers per channel is limited. The client will not initiate, mediate or accept a further pending transfer if the limit is reached. This is to avoid the risk of not being able to unlock the transfers, as the gas cost for this operation grows with the number of the pending locks and thus the number of pending transfers.
+
+The limit is currently set to 160. It is a rounded value that ensures the gas cost of unlocking will be less than 40% of Ethereum's traditional pi-million (3141592) block gas limit.

--- a/mediated_transfer.rst
+++ b/mediated_transfer.rst
@@ -21,7 +21,7 @@ Mediated Transfers
 
 A :term:`mediated transfer` is a hash-time-locked transfer. Currently raiden supports only one type of lock. The lock has an amount that is being transferred, a :term:`secrethash` used to verify the secret that unlocks it, and a :term:`lock expiration` to determine its validity.
 
-Mediated transfers have an :term:`initiator` and a :term:`target` and a number of mediators in between. The number of mediators can also be zero as these transfers can also be sent to a direct partner. Assuming ``N`` number of mediators, a mediated transfer will require ``10N + 16`` messages to complete. These are:
+Mediated transfers have an :term:`initiator` and a :term:`target` and a number of mediators in between. Assuming ``N`` number of mediators, a mediated transfer will require ``10N + 16`` messages to complete. These are:
 
 - ``N + 1`` :term:`locked transfer` or :term:`refund transfer` messages
 - ``1`` :term:`secret request`
@@ -50,6 +50,12 @@ For a simple example with one mediator:
 - Bob sends an ``Unlock`` message to Charlie. This acts also as a synchronization message informing Charlie that the lock will be removed from the list of pending locks and that the ``transferred_amount`` and ``locksroot`` values are updated.
 - Bob sends a ``RevealSecret`` message to Alice.
 - Finally Alice sends an ``Unlock`` to Bob, completing the transfer.
+
+.. note::
+
+  The number of mediators can also be zero. There are currently no dedicated message types for
+  direct transfers in Raiden, so a direct transfer is just realized as a mediated transfer with
+  no mediators.
 
 Mediated Transfer - Happy Path Scenario
 ---------------------------------------

--- a/messaging.rst
+++ b/messaging.rst
@@ -68,7 +68,7 @@ Fields
 +--------------------------+------------+--------------------------------------------------------------------------------+
 |  locksroot               | bytes32    | Hash of the pending locks encoded and concatenated                             |
 +--------------------------+------------+--------------------------------------------------------------------------------+
-| token_network_identifier | address    | Address of the TokenNetwork contract                                           |
+| token_network_address    | address    | Address of the TokenNetwork contract                                           |
 +--------------------------+------------+--------------------------------------------------------------------------------+
 |  channel_identifier      | uint256    | Channel identifier inside the TokenNetwork contract                            |
 +--------------------------+------------+--------------------------------------------------------------------------------+
@@ -524,8 +524,6 @@ This should match `the encoding implementation <https://github.com/raiden-networ
 
 Unlock
 ------
-
-.. Note:: At the current (15/02/2018) Raiden implementation as of commit ``cccfa572298aac8b14897ee9677e88b2b55c9a29`` this message is known in the codebase as ``Secret``.
 
 Non cancellable, Non expirable.
 

--- a/messaging.rst
+++ b/messaging.rst
@@ -7,8 +7,8 @@ Overview
 This is the specification of the messages used in the Raiden protocol.
 
 There are data structures which reappear in different messages:
-The :ref:`offchain balance proof <balance-proof-offchain>`
-and the :ref:`hash time lock <hash-time-lock>`.
+- The :ref:`offchain balance proof <balance-proof-offchain>`
+- and the :ref:`hash time lock <hash-time-lock>`.
 
 A :term:`mediated transfer` begins with a :ref:`LockedTransfer message <locked-transfer-message>`.
 
@@ -22,7 +22,7 @@ The further messages within the transfer are based on it:
 
 Further messages in the protocol are:
 
-- The :ref:`Processed <processed-message>` that is sent to confirm received messages, and
+- The :ref:`Processed <processed-delivered-message>` that is sent to confirm received messages, and
 - The withdraw-related messages :ref:`WithdrawRequest <withdraw-request-message>`,
   :ref:`WithdrawConfirmation <withdraw-confirmation-message>` and
   :ref:`WithdrawExpired <withdraw-expired-message>`.

--- a/messaging.rst
+++ b/messaging.rst
@@ -4,7 +4,29 @@ Raiden Messages Specification
 Overview
 ========
 
-This is the specification document for the messages used in the Raiden protocol.
+This is the specification of the messages used in the Raiden protocol.
+
+All messages are encoded in a JSON format and sent via our Matrix transport layer. There are
+data structures which reappear in different messages:
+The :ref:`offchain balance proof <balance-proof-offchain>`
+and the :ref:`hash time lock <hash-time-lock>`.
+
+A :term:`mediated transfer` begins with a :ref:`LockedTransfer message <locked-transfer-message>`.
+
+We will explain the assembly of a ``LockedTransfer`` message step-by-step below.
+The further messages within the transfer are based on it:
+
+- :ref:`SecretRequest <secret-request-message>`,
+  its reply :ref:`RevealSecret <reveal-secret-message>`, and
+  finally the :ref:`Unlock <unlock-message>` messages that complete the transfer.
+- The :ref:`LockExpired <lock-expired-message>` message in case the transfer is not completed in time.
+
+Further messages in the protocol are:
+
+- The :ref:`Processed <processed-message>` that is sent to confirm received messages, and
+- The withdraw-related messages :ref:`WithdrawRequest <withdraw-request-message>`,
+  :ref:`WithdrawConfirmation <withdraw-confirmation-message>` and
+  :ref:`WithdrawExpired <withdraw-expired-message>`.
 
 Data Structures
 ===============
@@ -50,6 +72,8 @@ Fields
 |  chain_id                | uint256    | Chain identifier as defined in EIP155                                          |
 +--------------------------+------------+--------------------------------------------------------------------------------+
 
+
+.. _hash-time-lock:
 
 HashTimeLock
 ------------
@@ -697,6 +721,14 @@ Fields
 |  signature                    | bytes         | Elliptic Curve 256k1 signature                                 |
 |                               |               | Signed data: see :ref:`withdraw-request-message`               |
 +-------------------------------+---------------+----------------------------------------------------------------+
+
+.. _processed-message:
+
+Processed message
+-----------------
+
+TODO
+
 
 Specification
 =============

--- a/messaging.rst
+++ b/messaging.rst
@@ -6,8 +6,7 @@ Overview
 
 This is the specification of the messages used in the Raiden protocol.
 
-All messages are encoded in a JSON format and sent via our Matrix transport layer. There are
-data structures which reappear in different messages:
+There are data structures which reappear in different messages:
 The :ref:`offchain balance proof <balance-proof-offchain>`
 and the :ref:`hash time lock <hash-time-lock>`.
 
@@ -27,6 +26,14 @@ Further messages in the protocol are:
 - The withdraw-related messages :ref:`WithdrawRequest <withdraw-request-message>`,
   :ref:`WithdrawConfirmation <withdraw-confirmation-message>` and
   :ref:`WithdrawExpired <withdraw-expired-message>`.
+
+Encoding and transport
+======================
+
+All messages are encoded in a JSON format and sent via our Matrix transport layer.
+
+The encoding used by the transport layer is independent of this specification, as
+long as the signatures using the data are encoded in the EVM big endian format.
 
 Data Structures
 ===============
@@ -724,80 +731,7 @@ Fields
 
 .. _processed-message:
 
-Processed message
------------------
+Processed
+----------
 
 TODO
-
-
-Specification
-=============
-
-The encoding used by the transport layer is independent of this specification, as long as the signatures using the data are encoded in the EVM big endian format.
-
-Transfers
----------
-
-The protocol supports mediated transfers. A :term:`Mediated transfer` may be cancelled and can expire unless the initiator reveals the secret.
-
-A mediated transfer is done in two stages, possibly on a series of channels:
-
-- Reserve token :term:`capacity` for a given payment, using a :ref:`locked transfer message <locked-transfer-message>`.
-- Use the reserved token amount to complete payments, using the :ref:`unlock message <unlock-message>`
-
-Message Flow
-------------
-
-Nodes may use mediated transfers to send payments.
-
-Mediated Transfer
-^^^^^^^^^^^^^^^^^
-
-A :term:`Mediated Transfer` is a hash-time-locked transfer. Currently raiden supports only one type of lock. The lock has an amount that is being transferred, a :term:`secrethash` used to verify the secret that unlocks it, and a :term:`lock expiration` to determine its validity.
-
-Mediated transfers have an :term:`initiator` and a :term:`target` and a number of mediators in between. The number of mediators can also be zero as these transfers can also be sent to a direct partner. Assuming ``N`` number of mediators, a mediated transfer will require ``10N + 16`` messages to complete. These are:
-
-- ``N + 1`` :term:`locked transfer` or :term:`refund transfer` messages
-- ``1`` :term:`secret request`
-- ``N + 2`` :term:`reveal secret`
-- ``N + 1`` :term:`unlock`
-- ``2N + 3`` processed (one for everything above)
-- ``5N + 8`` delivered
-
-For the simplest Alice - Bob example:
-
-- Alice wants to transfer ``n`` tokens to Bob.
-- Alice creates a new transfer with:
-    * transferred_amount = ``current_value``
-    * lock = ``Lock(n, hash(secret), expiration)``
-    * locked_amount = ``updated value containing the lock amount``
-    * locksroot = ``updated value containing the lock``
-    * nonce = ``current_value + 1``
-- Alice signs the transfer and sends it to Bob.
-- Bob requests the secret that can be used for withdrawing the transfer by sending a ``SecretRequest`` message.
-- Alice sends the ``RevealSecret`` to Bob and at this point she must assume the transfer is complete.
-- Bob receives the secret and at this point has effectively secured the transfer of ``n`` tokens to his side.
-- Bob sends a ``RevealSecret`` message back to Alice to inform her that the secret is known and acts as a request for off-chain synchronization.
-- Finally Alice sends an ``Unlock`` message to Bob. This acts also as a synchronization message informing Bob that the lock will be removed from the list of pending locks and that the transferred_amount and locksroot values are updated.
-
-**Mediated Transfer - Best Case Scenario**
-
-In the best case scenario, all Raiden nodes are online and send the final balance proofs off-chain.
-
-.. image:: diagrams/RaidenClient_mediated_transfer_good.png
-    :alt: Mediated Transfer Good Behaviour
-    :width: 900px
-
-**Mediated Transfer - Worst Case Scenario**
-
-In case a Raiden node goes offline or does not send the final balance proof to its payee, then the payee can register the ``secret`` on-chain, in the ``SecretRegistry`` smart contract before the ``secret`` expires. This can be used to ``unlock`` the lock on-chain after the channel is settled.
-
-.. image:: diagrams/RaidenClient_mediated_transfer_secret_reveal.png
-    :alt: Mediated Transfer Bad Behaviour
-    :width: 900px
-
-**Limit to number of simultaneously pending transfers**
-
-The number of simultaneously pending transfers per channel is limited. The client will not initiate, mediate or accept a further pending transfer if the limit is reached. This is to avoid the risk of not being able to unlock the transfers, as the gas cost for this operation grows with the number of the pending locks and thus the number of pending transfers.
-
-The limit is currently set to 160. It is a rounded value that ensures the gas cost of unlocking will be less than 40% of Ethereum's traditional pi-million (3141592) block gas limit.

--- a/terminology.rst
+++ b/terminology.rst
@@ -13,6 +13,9 @@ Raiden Terminology
    channel identifier
        Identifier assigned by :term:`Token Network` to a :term:`Payment Channel`. Must be unique inside the :term:`Token Network` contract. See the :ref:`implementation definition <channel-identifier>`.
 
+   canonical identifier
+       The globally unique identifier of a channel, consisting of the :term:`channel identifier`, the chain identifier and the :term:`Token Network` address.
+
    Unidirectional Payment Channel
        Payment Channel where the roles of :term:`Initiator` and :term:`Target` are determined in the channel creation and cannot be changed.
 
@@ -65,6 +68,9 @@ Raiden Terminology
 
    locked amount
        Total amount of tokens locked in all currently pending :term:`HTL` transfers sent by a channel participant. This amount corresponds to the :term:`locksroot` of the HTL locks.
+
+   balance data
+       The data relevant to a channel's balance: :term:`locked amount`, :term:`transferred amount` and :term:`locksroot`.
 
    secrethash
        The hash of a :term:`secret`.  ``sha3_keccack(secret)``


### PR DESCRIPTION
The message format tables are still not up-to-date. There will be a follow-up for that.

Some changes to the messaging specification:
- add an Overview section (as is planned for all chapters of the spec)
- add some missing message and data structure descriptions
- structure the text better
- elaborate more on the structure of the balance proof
- move the transfer specification into an own chapter