### PR TITLE
Add config file and disable output formats

### DIFF
--- a/readthedocs.yaml
+++ b/readthedocs.yaml
@@ -1,0 +1,15 @@
+# readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  configuration: conf.py
+  fail_on_warning: true
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# No additional formats used to speed up doc build.
+formats: []


### PR DESCRIPTION
Using a config file is the recommended way to configure readthedocs. So
far we only used the web config UI.

Using this config file, I turned of all additional output formats fix
https://github.com/raiden-network/spec/issues/248. HTML & JSON are still
built.

I don't see a way to test this without merging, so it's untested.