### PR TITLE
Consistent chapter titles / consistent table of contents

### DIFF
--- a/mediation_fees.rst
+++ b/mediation_fees.rst
@@ -1,5 +1,5 @@
-Raiden Mediation Fee Specification
-##################################
+Mediation Fees
+##############
 
 Overview
 ========

--- a/messaging.rst
+++ b/messaging.rst
@@ -1,5 +1,5 @@
-Raiden Messages Specification
-#############################
+Messages
+########
 
 Overview
 ========

--- a/mobile_wallet.rst
+++ b/mobile_wallet.rst
@@ -1,5 +1,5 @@
-Raiden Mobile Wallet Specification
-##################################
+Mobile Wallet
+#############
 
 (This is work in progress and will be updated as soon as integration related specifications for core protocol and other services are settled on and implemented)
 

--- a/monitoring_service.rst
+++ b/monitoring_service.rst
@@ -1,7 +1,7 @@
 .. _ms:
 
-Raiden Monitoring Service
-#########################
+Monitoring Service
+##################
 
 
 Summary

--- a/pathfinding_service.rst
+++ b/pathfinding_service.rst
@@ -1,7 +1,7 @@
 .. _pfs:
 
-Raiden Pathfinding Service
-##########################
+Pathfinding Service
+###################
 
 Overview
 ========

--- a/service_contracts.rst
+++ b/service_contracts.rst
@@ -1,5 +1,5 @@
-Smart Contracts for Raiden Services
-###################################
+Smart Contracts for the Services
+################################
 
 Overview
 ========

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -1,5 +1,5 @@
-Raiden Network Smart Contracts Specification
-############################################
+Smart Contracts for the Network
+###############################
 
 Overview
 ========

--- a/terminology.rst
+++ b/terminology.rst
@@ -1,5 +1,5 @@
-Raiden Terminology
-==================
+Terminology
+===========
 
 .. glossary::
    :sorted:

--- a/transport.rst
+++ b/transport.rst
@@ -1,5 +1,5 @@
-Raiden Transport
-################
+Transport
+#########
 
 Requirements
 ============


### PR DESCRIPTION
Do not repeat the words "Raiden" or "Specification" in chapter titles.

Related issue: #252