### PR TITLE
Same balance proof update should not be repeated

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -604,6 +604,8 @@ Called after a channel has been closed. Can be called by any Ethereum address an
 
     Only a valid signed `balance proof update`__  ``MUST`` be accepted. This update is a confirmation from the ``non-closing participant`` that the contained :term:`balance proof` can be set on his behalf.
 
+    The same `balance proof update`__ ``MUST NOT`` be accepted multiple times. This prevents Monitoring Services from getting rewards again and again using the same reward proof.
+
     __ balance-proof-update-on-chain_
 
 .. _settle-channel:


### PR DESCRIPTION
because otherwise Monitoring Services can gain
rewards again and again using the same reward proof.