### PR TITLE
Neutralize language

### DIFF
--- a/messaging.rst
+++ b/messaging.rst
@@ -31,7 +31,7 @@ Further messages in the protocol are:
 Encoding, signing and transport
 ===============================
 
-All messages are encoded in a JSON format and sent via our Matrix transport layer.
+All messages are encoded in a JSON format and sent via the Matrix transport layer.
 
 The encoding used by the transport layer is independent of this specification, as
 long as the signatures using the data are encoded in the EVM big endian format.

--- a/monitoring_service.rst
+++ b/monitoring_service.rst
@@ -6,14 +6,14 @@ Monitoring Service
 
 Summary
 =======
-*   Monitoring Service (MS) listens to Monitor Requests (MRs - blinded Balance Proofs) and offered rewards in a public Matrix Room
-*   Any pre-registered MS can decide to monitor a channel and store corresponding MRs
-*   Then, whenever a channel is closed by calling ``closeChannel`` and after a period of x blocks where the client is
-    expected the react, the MS will call ``updateNonClosingBalanceProof`` with the submitted MR by its client
-*   Rewards are paid in RDN, there is no free tier
-*   In the short term we go for a simple design which will allow us to reach the Ithaca milestone earlier
-*   In the long-term we see the PISA approach as more economically viable and user friendly, but this design requires
-    additional features and can be developed independently after Ithaca
+*   A Monitoring Service (MS) listens to Monitor Requests (MRs - blinded Balance Proofs) in a public "broadcast" Matrix room. An MR is accompanied by an offered reward for acting on it.
+*   Any pre-registered MS can decide to monitor a channel and store the corresponding MRs.
+*   Then, whenever a channel is closed by calling ``closeChannel`` and if the client did not react within a specified
+  timeout, the MS will call ``updateNonClosingBalanceProof`` with the submitted MR on behalf of its client.
+*   Rewards are paid in RDN, there is no free tier.
+*   In the current stage, this is a simple design which is expected to help to reach the Ithaca milestone earlier
+*   In the long-term a PISA approach seems more economically viable and user friendly, but this design requires
+    additional features and can be developed independently after Ithaca.
 
 Usual Scenario
 ==============


### PR DESCRIPTION
- This chooses neutral language over first person speech, where applicable.
- This PR also tries to make some sentences easier to parse for humans.