### PR TITLE
Mention different monitoring period for different

### DIFF
--- a/service_contracts.rst
+++ b/service_contracts.rst
@@ -338,3 +338,5 @@ To handle the rewards, the MonitoringService contract provides two functions. ``
 
 .. autosolcontract:: MonitoringService
     :members: monitor, claimReward
+
+In order to avoid an unproductive race between service providers, for the same participant on the same channel, different service providers have different block number from which they can call ``monitor()``.  Here we are not trying to get randomness, but merely trying to make differences in a fair way.


### PR DESCRIPTION
Monitoring Services.

Because if all Monitoring Services can start at the same block,
there will be a race.

This trick was added in
https://github.com/raiden-network/raiden-contracts/pull/909
but I didn't find it mentioned in the spec.