### PR TITLE
Describe approximation-free mediation fees

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -40,7 +40,12 @@ release = '0.1'
 extensions = [
     'sphinx.ext.autodoc',
     'sphinxcontrib.soliditydomain',
+    'matplotlib.sphinxext.plot_directive',
 ]
+
+# configure plot_directive extension
+plot_html_show_source_link = False
+plot_html_show_formats = False
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/mediation_fees.rst
+++ b/mediation_fees.rst
@@ -161,12 +161,14 @@ equivalent to finding the zero of
 .. math::
    f(x_{out}) = round(\mathit{fee}_{\mathit{in}}(\mathit{x_{in}}) + \mathit{fee}_{\mathit{out}}(-\mathit{x_{out}})) - x_{in} + x_{out}
 
-Due to the constraints on the fee schedule, this function is monotonically
+Due to the constraints [#cons]_ on the fee schedule, this function is monotonically
 decreasing. Thus there is only a single solution and it can be found easily by
 following the slope into the right direction. Additionally, the current
 implementation uses the fact that the mediation fees are a piecewise linear
 function by only searching for the section that includes the solution and then
 interpolating to get the exact solution.
+
+.. [#cons] ``PROPORTIONAL_MED_FEE_MAX`` + 2 * ``MAXIMUM_SLOPE`` must be strictly below 1, where ``MAXIMUM_SLOPE`` is the highest absolute slope allowed at any point of the IP function.
 
 Backward calculation (in the PFS)
 ------------------------------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-soliditydomain
+matplotlib


### PR DESCRIPTION
In https://github.com/raiden-network/raiden/pull/5089/files we changed
the mediation fee calculation to increase the accuracy and allow capping
the mediation fees in a sensible way. This commit brings the description
in line with the code, again.

Closes https://github.com/raiden-network/raiden-services/issues/410