### PR TITLE
Add withdraw diagram 

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -41,6 +41,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinxcontrib.soliditydomain',
     'matplotlib.sphinxext.plot_directive',
+    'sphinxcontrib.mermaid',
 ]
 
 # configure plot_directive extension

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sphinx<3.0
 sphinx_rtd_theme
 sphinxcontrib-soliditydomain
+sphinxcontrib-mermaid
 matplotlib

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -845,6 +845,31 @@ Unlocking Pending Transfers
     :alt: Channel Unlock Pending Transfers
     :width: 500px
 
+Withdraw
+--------
+
+Tokens can be :ref:`withdrawn <withdraw-channel>` from a payment channel without closing the channel, if the other participant is online and cooperates.
+
+.. mermaid::
+
+   sequenceDiagram
+      participant Alice
+      participant Bob
+      participant TokenNetwork
+      Alice->>Bob: WithdrawRequest
+      Bob->>Alice: WithdrawConfirmation
+      Alice->>TokenNetwork: setTotalWithdraw
+
+If the withdraw expires before it could be used (e.g. because Bob did not cooperate), a WithdrawExpired message is sent to clear the withdraw state across both nodes.
+
+.. mermaid::
+
+   sequenceDiagram
+      participant Alice
+      participant Bob
+      Alice->>Bob: WithdrawRequest
+      Alice->>Bob: WithdrawExpired
+
 
 .. _settlement-algorithm:
 


### PR DESCRIPTION
We didn't add one when we added withdraw to the protocol. I added support for mermaid diagrams to do this easily.

See https://raiden-network-specification--340.org.readthedocs.build/en/340/smart_contracts.html#withdraw for the preview.