### PR TITLE
Update TokenNetwork contract

### DIFF
--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -480,6 +480,34 @@ Deposit more tokens into a channel. This will only increase the deposit of one o
 
     A participant or a delegate ``MUST`` be able to deposit more tokens into a channel, regardless of his partner's availability.
 
+
+.. _open-deposit-channel:
+
+Open channel with funding
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This is an optimisation that combines opening and funding a channel in one transaction.
+It will open a new channel between `participant1` and `participant2` and make a deposit for `participant1`. 
+Can be called by anyone, as long as the deposited funds have been approved as in the :ref:``depositChannel <deposit-channel>`` function.
+
+::
+
+    function openChannelWithDeposit(
+        address participant1,
+        address participant2,
+        uint256 settle_timeout,
+        uint256 participant1_total_deposit
+    )
+        public
+
+
+- ``participant1``: Ethereum address of a channel participant
+- ``participant2``: Ethereum address of the other channel participant
+- ``settle_timeout``: Number of blocks that need to be mined between a call to closeChannel and settleChannel
+- ``participant1_total_deposit``: The total amount of tokens that ``participant1`` will have as deposit
+
+As the :ref:``depositChannel <deposit-channel>`` function, a successful call to this function will emit a `ChannelNewDeposit` event in the same way.
+
 .. _withdraw-channel:
 
 Withdraw tokens from a channel

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -506,7 +506,7 @@ Can be called by anyone, as long as the deposited funds have been approved as in
 - ``settle_timeout``: Number of blocks that need to be mined between a call to closeChannel and settleChannel
 - ``participant1_total_deposit``: The total amount of tokens that ``participant1`` will have as deposit
 
-As the :ref:``depositChannel <deposit-channel>`` function, a successful call to this function will emit a `ChannelNewDeposit` event in the same way.
+As the :ref:``depositChannel <deposit-channel>`` function, a successful call to this function will emit a `ChannelNewDeposit` event in the same way and same block (so clients must ensure they're able to react to deposit events inclusive on the block when `ChannelOpen` was detected).
 
 .. _withdraw-channel:
 

--- a/smart_contracts.rst
+++ b/smart_contracts.rst
@@ -796,7 +796,7 @@ Unlocks all pending transfers by providing all pending transfers data. The hash 
 Turning on the deprecation switch
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Allows the deprecation executor to deprecate the contract. After this no channels accept new deposits, and no new channel can be opened.
+Allows the controller to deprecate the contract. After this no channels accept new deposits, and no new channel can be opened.
 
 ::
 


### PR DESCRIPTION
- added the `TokenNetwork.openChannelWithDeposit` to the contracts
- renamed a mention of the deprecation executor for the TokenNetwork contract